### PR TITLE
rename IMAS-Paraview to IMAS-ParaView

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,25 +1,25 @@
 # Contributing guidelines
 
-We welcome any kind of contribution to `IMAS-Paraview`, 
+We welcome any kind of contribution to `IMAS-ParaView`, 
 from a simple comment, a question or even a full fledged pull 
 request. 
 Please first make sure you read and follow the 
 [Code of Conduct](CODE_OF_CONDUCT.md).
 
 ## You think you found a bug in the code, or have a question in its use
-1. use the [issue search](https://github.com/iterorganization/IMAS-Paraview/issues)
+1. use the [issue search](https://github.com/iterorganization/IMAS-ParaView/issues)
 to check if someone already created a similar issue;
-2. if not, make a [new issue](https://github.com/iterorganization/IMAS-Paraview/issues/new/choose) to describe your problem or question. 
+2. if not, make a [new issue](https://github.com/iterorganization/IMAS-ParaView/issues/new/choose) to describe your problem or question. 
 In the case of a bug suspiscion, please try to give all the relevant 
 information to allow reproducing the error or identifying 
-its root cause (version of the IMAS-Paraview, OS and relevant 
+its root cause (version of the IMAS-ParaView, OS and relevant 
 dependencies, snippet of code);
 3. apply relevant labels to the issue.
 
 ## You want to make or ask some change to the code
-1. use the [issue search](https://github.com/iterorganization/IMAS-Paraview/issues)
+1. use the [issue search](https://github.com/iterorganization/IMAS-ParaView/issues)
 to check if someone already proposed a similar idea/change;
-2. if not, create a [new issue](https://github.com/iterorganization/IMAS-Paraview/issues/new/choose) to describe what change you would like to see 
+2. if not, create a [new issue](https://github.com/iterorganization/IMAS-ParaView/issues/new/choose) to describe what change you would like to see 
 implemented and specify it if you intend to work on it yourself or if some help 
 will be needed;
 3. wait until some kind of consensus is reached about your idea being relevant, 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# IMAS-Paraview
-IMAS-Paraview is a tool to convert GGD ([Generalized Grid Description](https://imas-data-dictionary.readthedocs.io/en/latest/ggd_guide/doc.html)) 
+# IMAS-ParaView
+IMAS-ParaView is a tool to convert GGD ([Generalized Grid Description](https://imas-data-dictionary.readthedocs.io/en/latest/ggd_guide/doc.html)) 
 structures to VTK formats, and back. This is complemented by a number of Paraview plugins that can visualise both GGD and non-GGD IDS data in Paraview. 
 
 For an overview of the different types of IDS data that can be loaded, see the [documentation](https://sharepoint.iter.org/departments/POP/CM/IMDesign/Code%20Documentation/GGD-VTK/usage.html).
@@ -53,7 +53,7 @@ pip install --upgrade wheel setuptools
 pip install -e .[all]
 # Run CLI with help information
 imas-paraview --help
-# If you see the help page of IMAS-Paraview, it is installed correctly.
+# If you see the help page of IMAS-ParaView, it is installed correctly.
 ```
 
 ## Documentation

--- a/ci/build_docs.sh
+++ b/ci/build_docs.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Bamboo CI script to build the IMAS-Paraview docs
+# Bamboo CI script to build the IMAS-ParaView docs
 # Note: this script should be run from the root of the git repository
 
 # Debuggging:

--- a/ci/run_benchmark.sh
+++ b/ci/run_benchmark.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Bamboo CI script to install IMAS-Paraview and run all benchmarks
+# Bamboo CI script to install IMAS-ParaView and run all benchmarks
 # Note: this script should be run from the root of the git repository
 
 # Debuggging:

--- a/ci/run_pytest.sh
+++ b/ci/run_pytest.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Bamboo CI script to install IMAS-Paraview and run all tests
+# Bamboo CI script to install IMAS-ParaView and run all tests
 # Note: this script should be run from the root of the git repository
 
 # Debuggging:

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -1,11 +1,11 @@
 API reference
 =============
 
-This page provides an auto-generated summary of IMAS-Paraview's API. For more details
+This page provides an auto-generated summary of IMAS-ParaView's API. For more details
 and examples, refer to the relevant chapters in the main part of the
 documentation.
 
-IMAS-Paraview
+IMAS-ParaView
 -------------
 
 .. autosummary::

--- a/docs/source/ci_config.rst
+++ b/docs/source/ci_config.rst
@@ -3,17 +3,17 @@
 CI configuration
 ================
 
-IMAS-Paraview uses `ITER Bamboo <https://ci.iter.org/>`_ for CI. This page provides an overview
+IMAS-ParaView uses `ITER Bamboo <https://ci.iter.org/>`_ for CI. This page provides an overview
 of the CI Plan and deployment projects. Some of the jobs in the CI Plan can also be run manually,
 examples provided below.
 
 CI Plan
 -------
 
-The `IMAS-Paraview CI plan <https://ci.iter.org/browse/VIS-GGDVTK>`_ consists of 3 types of jobs:
+The `IMAS-ParaView CI plan <https://ci.iter.org/browse/VIS-GGDVTK>`_ consists of 3 types of jobs:
 
 Linting 
-    Run ``black``, ``flake8``, and ``isort`` on the IMAS-Paraview code base.
+    Run ``black``, ``flake8``, and ``isort`` on the IMAS-ParaView code base.
     See :ref:`code style and linting`.
 
     The CI script executed in this job is ``ci/linting.sh``.
@@ -73,11 +73,11 @@ Build docs
 Deployment projects
 -------------------
 
-There is currently one Bamboo deployment project for IMAS-Paraview:
+There is currently one Bamboo deployment project for IMAS-ParaView:
 
-`Deploy IMAS-Paraview Docs <https://ci.iter.org/deploy/viewDeploymentProjectEnvironments.action?id=1942093825>`_
+`Deploy IMAS-ParaView Docs <https://ci.iter.org/deploy/viewDeploymentProjectEnvironments.action?id=1942093825>`_
     Deploy the documentation created in the `Build docs` job to `Sharepoint
     <https://sharepoint.iter.org/departments/POP/CM/IMDesign/Code%20Documentation/GGD-VTK/index.html#>`_.
 
-    This deployment project runs for after each successful CI build of the IMAS-Paraview main
+    This deployment project runs for after each successful CI build of the IMAS-ParaView main
     branch.

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -6,7 +6,7 @@ This page go over how to use the CLI interface to convert a GGD to VTK.
 
 Convert GGD to VTK using the CLI
 --------------------------------
-IMAS-Paraview supports converting the GGD of an IDS to VTK format from a command-line interface (CLI).
+IMAS-ParaView supports converting the GGD of an IDS to VTK format from a command-line interface (CLI).
 This can be done by using the `ggd2vtk` tool. 
 
 .. tip:: Detailed usage of the CLI tool can be found by running ``ggd2vtk --help``

--- a/docs/source/code_style.rst
+++ b/docs/source/code_style.rst
@@ -7,7 +7,7 @@ Code style and linting
 Code style
 ----------
 
-IMAS-Paraview follows `The Black Code Style
+IMAS-ParaView follows `The Black Code Style
 <https://black.readthedocs.io/en/stable/the_black_code_style/index.html>`_. All Python
 files should be formatted with the ``black`` command line tool (this is checked in
 :ref:`CI <ci configuration>`).
@@ -48,8 +48,8 @@ with pre-commit hooks):
 Linting
 -------
 
-IMAS-Paraview uses `flake8 <https://flake8.pycqa.org/en/latest/>`_ for linting (static code
-analysis). Flake8 should not report any violations when running it on the ``IMAS-Paraview``
+IMAS-ParaView uses `flake8 <https://flake8.pycqa.org/en/latest/>`_ for linting (static code
+analysis). Flake8 should not report any violations when running it on the ``IMAS-ParaView``
 code base. Again, this is checked in CI.
 
 In some exceptions we can ignore a violation. For example, if a violation cannot be
@@ -79,7 +79,7 @@ your code introduces any violations:
 
 Import sorting
 --------------
-IMAS-Paraview uses `isort <https://pycqa.github.io/isort/>`_ for automatic import sorting separated by type.
+IMAS-ParaView uses `isort <https://pycqa.github.io/isort/>`_ for automatic import sorting separated by type.
 
 Using isort
 '''''''''''

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -40,7 +40,7 @@ imas_repos = urljoin(iter_projects, "IMAS/")
 imex_repos = urljoin(iter_projects, "IMEX/")
 issue_url = jira_url = "https://jira.iter.org/browse/"
 
-# IMAS-Paraview
+# IMAS-ParaView
 repository_url = f"{iter_projects}/{src_group}/repos/{src_project}/"
 blob_url = urljoin(repository_url, "browse/")
 mr_url = urljoin(repository_url, "/pull-requests")

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -5,10 +5,10 @@
    define TOC here, but it'll be put in the sidebar by the theme
 
 ====================
-IMAS-Paraview Manual
+IMAS-ParaView Manual
 ====================
 
-IMAS-Paraview is a tool to convert GGD (Generalized Grid Description) structures to VTK formats, and back.
+IMAS-ParaView is a tool to convert GGD (Generalized Grid Description) structures to VTK formats, and back.
 This is complemented by a number of Paraview plugins that can visualise both GGD and non-GGD IDS data in Paraview.
 
 

--- a/docs/source/installing.rst
+++ b/docs/source/installing.rst
@@ -1,12 +1,12 @@
 .. _`installing`:
 
-Installing IMAS-Paraview
+Installing IMAS-ParaView
 ========================
 
-If the IMAS-Paraview module is available on your HPC environment, you can ignore the further 
+If the IMAS-ParaView module is available on your HPC environment, you can ignore the further 
 steps below and simply load the module as follows:
 
-# TODO: Change module name when new IMAS-Paraview easybuild module is available
+# TODO: Change module name when new IMAS-ParaView easybuild module is available
 .. code-block:: bash
 
   module load GGD-VTK
@@ -63,7 +63,7 @@ SDCC installation
   pip install -e .[all]
   # Run CLI with help information
   imas-paraview --help
-  # If you see the help page of IMAS-Paraview, it is installed correctly.
+  # If you see the help page of IMAS-ParaView, it is installed correctly.
 
 * Every time that a new session is started, ensure the correct modules are loaded, 
   the python virtual environment is activated, and the environment variables are set.
@@ -93,7 +93,7 @@ SDCC installation
   # Alternatively, if you want to skip running the integration tests
   python -m pytest -m "not integration"
 
-* To build the IMAS-Paraview documentation, ensure the optional docs dependencies are pip 
+* To build the IMAS-ParaView documentation, ensure the optional docs dependencies are pip 
   installed (or simply use all, to install all optional dependencies).
 
 .. code-block:: bash

--- a/imas_paraview/__main__.py
+++ b/imas_paraview/__main__.py
@@ -1,7 +1,7 @@
-"""Support module to run IMAS-Paraview as a module:
+"""Support module to run IMAS-ParaView as a module:
 
 .. code-block:: bash
-    :caption: Options to run IMAS-Paraview CLI interface
+    :caption: Options to run IMAS-ParaView CLI interface
 
     # Run as a module (implemented in imas_paraview/__main__.py)
     python -m imas_paraview

--- a/imas_paraview/cli.py
+++ b/imas_paraview/cli.py
@@ -30,7 +30,7 @@ def _excepthook(type_, value, tb):
 @click.group("imas-paraview", invoke_without_command=True, no_args_is_help=True)
 @click.option("-v", "--version", is_flag=True, help="Show version information")
 def cli(version):
-    """IMAS-Paraview command line interface.
+    """IMAS-ParaView command line interface.
 
     Please use one of the available commands listed below. You can get help for each
     command by executing:
@@ -46,15 +46,15 @@ def cli(version):
 
 
 def print_version():
-    """Print version information of IMAS-Paraview."""
+    """Print version information of IMAS-ParaView."""
     cons = console.Console()
     grid = Table(
-        title="IMAS-Paraview version info", show_header=False, title_style="bold"
+        title="IMAS-ParaView version info", show_header=False, title_style="bold"
     )
     grid.box = box.HORIZONTALS
     if cons.size.width > 120:
         grid.width = 120
-    grid.add_row("IMAS-Paraview version:", imas_paraview.__version__)
+    grid.add_row("IMAS-ParaView version:", imas_paraview.__version__)
     grid.add_section()
     grid.add_row("IMAS-Python version:", imas.__version__)
     grid.add_section()

--- a/imas_paraview/plugins/vtkggdwriter.py
+++ b/imas_paraview/plugins/vtkggdwriter.py
@@ -151,7 +151,7 @@ class GGDWriter(VTKPythonAlgorithmBase):
         ids_obj.ids_properties.provider = getpass.getuser()
         ids_obj.ids_properties.creation_date = str(datetime.datetime.today())
 
-        ids_obj.code.name = "IMAS-Paraview"
+        ids_obj.code.name = "IMAS-ParaView"
         ids_obj.code.version = get_versions()["version"]
         ids_obj.code.commit = get_versions()["full-revisionid"]
         ids_obj.code.repository = "https://git.iter.org/scm/imex/ggd-vtk.git"

--- a/imas_paraview/tests/test_cli.py
+++ b/imas_paraview/tests/test_cli.py
@@ -18,7 +18,7 @@ def test_version():
 
     result = runner.invoke(cli, ["--version"])
     assert result.exit_code == 0
-    assert "IMAS-Paraview version:" in result.output
+    assert "IMAS-ParaView version:" in result.output
     assert "IMAS-Python version:" in result.output
     assert "Default data dictionary version:" in result.output
     assert "Available data dictionary versions:" in result.output

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,9 +3,9 @@ requires = ["setuptools>=61", "wheel", "tomli;python_version<'3.11'", "versionee
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "IMAS-Paraview"
+name = "IMAS-ParaView"
 authors = [
-    {name = "IMAS-Paraview developers"},
+    {name = "IMAS-ParaView developers"},
     {name = "Panchumarti Jaswant EXT", email = "jaswant.panchumarti@iter.org"},
     {name = "Olivier Hoenen", email = "olivier.hoenen@iter.org"},
 ]


### PR DESCRIPTION
Update naming of all occurrences of `IMAS-Paraview` to `IMAS-ParaView` (with a capital 'V').