### PR TITLE
Update CI workflow: replace docker image with binaries from paraview website

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,13 +45,13 @@ jobs:
         python-version: '3.10'
 
     - name: Cache paraview
-      id: cache-npm
+      id: cache-paraview
       uses: actions/cache@v4
       with:
         path: paraview/
         key: ${{ env.paraview-download-file }}
 
-    - if: ${{ steps.cache-npm.outputs.cache-hit != 'true' }}
+    - if: ${{ steps.cache-paraview.outputs.cache-hit != 'true' }}
       name: Download paraview binaries
       run: |
         wget "https://www.paraview.org/paraview-downloads/download.php?submit=Download&version=v5.13&type=binary&os=Linux&downloadFile=${{ env.paraview-download-file }}" -O paraview.tar.gz

--- a/imas_paraview/tests/test_cli.py
+++ b/imas_paraview/tests/test_cli.py
@@ -26,7 +26,6 @@ def test_version():
     assert "Access Layer core version:" in result.output
 
 
-@pytest.mark.skip(reason="issue with netcdf")
 def test_ggd2vtk(tmp_path, dummy_ids):
     uri = f"{tmp_path}/testdb.nc"
     with imas.DBEntry(uri, "w") as dbentry:

--- a/imas_paraview/tests/test_convert.py
+++ b/imas_paraview/tests/test_convert.py
@@ -23,7 +23,6 @@ def test_ggd_to_vtk(dummy_ids):
     assert vtk_array_names == ggd_names
 
 
-@pytest.mark.skip(reason="issue with netcdf")
 def test_ggd_to_vtk_reference(tmp_path):
     """Test if ggd_to_vtk works with a reference grid."""
 


### PR DESCRIPTION
This PR changes the pytest job to download the ParaView binaries from their website instead of the paraview-for-ci docker image.
This has the following advantages:

- The `paraview-for-ci` Docker image is based on an old version of ubuntu (20.04) with outdated Python, netCDF, HDF5 etc. libraries. Using the `ubuntu-latest` runner and installing the Paraview binaries fixes the netCDF library issues noted in #2 
- We can use the `setup-python` to create our python environment, which is faster than installing python with apt-get
- The ParaView binaries can be cached easily (see the Cache paraview step), which would've been more difficult with the Docker image