### PR TITLE
Fix benchmark CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,8 +104,8 @@ jobs:
       run: |
         git fetch origin develop:refs/remotes/origin/develop
         git fetch origin master:refs/remotes/origin/master
-        git branch develop origin/develop
-        git branch master origin/master
+        git show-ref --verify --quiet refs/heads/develop || git branch develop origin/develop
+        git show-ref --verify --quiet refs/heads/master || git branch master origin/master
 
     - name: Set up Python
       uses: actions/setup-python@v3


### PR DESCRIPTION
The current develop CI fails, as the benchmark job tries to create the already existing `develop` branch. This fixes this, such that the `develop` and `master` branches are only created if they do not exist yet.