### PR TITLE
Rename LoS Reader to Line of Sight Reader

### DIFF
--- a/docs/source/los_reader.rst
+++ b/docs/source/los_reader.rst
@@ -1,9 +1,9 @@
-.. _`using the LoS Reader`:
+.. _`using the Line of Sight Reader`:
 
-LoS (Line of Sight) Reader
-==========================
+Line of Sight Reader
+====================
 
-This page explains how to use the LoS (Line-of-Sight) Reader to visualize Line of sight IDS data structures.
+This page explains how to use the Line of Sight Reader to visualize Line of sight IDS data structures.
 
 
 Supported IDSs
@@ -41,10 +41,10 @@ Currently, the following IDS and structures are supported in the Line of Sight R
    * - ``spectrometer_visible``
      - `Channels <https://imas-data-dictionary.readthedocs.io/en/latest/generated/ids/spectrometer_visible.html#spectrometer_visible-channel-line_of_sight>`__
 
-Using the LoS Reader
---------------------
+Using the Line of Sight Reader
+------------------------------
 
-The LoS Reader functions similarly to the GGD Reader, with the same interface and data loading workflow. 
+The Line of Sight Reader functions similarly to the GGD Reader, with the same interface and data loading workflow. 
 This means that the steps for loading an URI, an IDS, and selecting attributes are identical. 
 Refer to the :ref:`using the GGD Reader` for detailed instructions on:
 
@@ -56,7 +56,7 @@ Refer to the :ref:`using the GGD Reader` for detailed instructions on:
 Setting the Scaling Factor
 --------------------------
 
-The LoS allows you the change the length the of the line-of-sight, using the 
+The Line of Sight Reader allows you the change the length the of the line-of-sight, using the 
 ``Scaling Factor``. This factor allows you to scale the line-of-sight to be either longer or shorter 
 than its original length. Additionally, the Scaling Factor can be set to a negative value, 
 which will invert the direction of the line-of-sight.
@@ -67,8 +67,8 @@ which will invert the direction of the line-of-sight.
    :header-rows: 0
 
    * - .. figure:: images/los_1.png
-         :alt: LoS at Scaling Factor 1
+         :alt: Line of Sight at Scaling Factor 1
      - .. figure:: images/los_1_5.png
-         :alt: LoS at Scaling Factor 1.5
+         :alt: Line of Sight at Scaling Factor 1.5
    * - Line of sights of vacuum vessel cameras in bolometer IDS, with ``Scaling Factor`` at 1 (default).
      - Line of sights of vacuum vessel cameras in bolometer IDS, with ``Scaling Factor`` at 1.5.

--- a/imas_paraview/plugins/line_of_sight.py
+++ b/imas_paraview/plugins/line_of_sight.py
@@ -46,7 +46,7 @@ class LineOfSight:
     line_of_sight: IDSStructure
 
 
-@smproxy.source(label="LoS Reader")
+@smproxy.source(label="Line of Sight Reader")
 @smhint.xml("""<ShowInMenu category="IMAS Tools" />""")
 class LineOfSightReader(GGDVTKPluginBase):
     """Line of sight reader based on IMAS-Python"""


### PR DESCRIPTION
This changes the name of the `LoS Reader` to the unabbreviated `Line of Sight Reader`. This makes the purpose of the reader more clear. The documentation was also updated to reflect this change.

![Screenshot (5)](https://github.com/user-attachments/assets/a4a113e3-593d-470e-93a2-b3bb085fdd95)
