### PR TITLE
Fix path attribute error

### DIFF
--- a/imas_paraview/convert.py
+++ b/imas_paraview/convert.py
@@ -102,7 +102,7 @@ class Converter:
             logger.warning("Could not load a valid GGD grid.")
             return None
 
-        if self.grid_ggd.path:
+        if hasattr(self.grid_ggd, "path") and self.grid_ggd.path:
             self.reference_grid_path = self.grid_ggd.path
             self._replace_grid_with_reference()
         else:


### PR DESCRIPTION
Fix fixes the issue trying to load the wall IDS with the GGD reader using the following URI: 
`imas:mdsplus?path=/work/imas/shared/imasdb/ITER_MD/3/116100/2001`

It seems like the path attribute did not yet exist at this version of the DD, which causes an AttributeError:
```
╭───── IDS structure: description_ggd[0]/grid_ggd[0] (DD version 3.37.0) ──────╮
│ Wall geometry described using the Generic Grid Description, for various time │
│ slices (in case of mobile wall elements). The timebase of this array of      │
│ structure must be a subset of the timebase on which physical quantities are  │
│ described (../ggd structure). Grid_subsets are used to describe various      │
│ wall components in a modular way.                                            │
│ ╭─────────────────────────────── Attributes ───────────────────────────────╮ │
│ │ metadata = <IDSMetadata for 'grid_ggd'>                                  │ │
│ ╰──────────────────────────────────────────────────────────────────────────╯ │
│ ╭────────────────────────────── Child nodes ───────────────────────────────╮ │
│ │ grid_subset = <IDSStructArray (IDS:wall,                                 │ │
│ │               description_ggd[0]/grid_ggd[0]/grid_subset with 0 items)>  │ │
│ │  identifier = <IDSStructure (IDS:wall,                                   │ │
│ │               description_ggd[0]/grid_ggd[0]/identifier)>                │ │
│ │       space = <IDSStructArray (IDS:wall,                                 │ │
│ │               description_ggd[0]/grid_ggd[0]/space with 1 items)>        │ │
│ │        time = <IDSFloat0D (IDS:wall,                                     │ │
│ │               description_ggd[0]/grid_ggd[0]/time, empty FLT_0D)>        │ │
│ ╰──────────────────────────────────────────────────────────────────────────╯ │
╰──────────────────────────────────────────────────────────────────────────────╯

```