### PR TITLE
Assume that IDSAndOccurrence receives a valid value from ParaView

### DIFF
--- a/imas_paraview/plugins/base_class.py
+++ b/imas_paraview/plugins/base_class.py
@@ -281,7 +281,7 @@ class GGDVTKPluginBase(VTKPythonAlgorithmBase, ABC):
         selecting a URI to load the Data Entry), or when the loaded Data Entry contains
         no IDSs supported by this plugin.
         """
-        if value not in self._ids_list or value == "<Select IDS>":
+        if value == "<Select IDS>":
             self._selectable = []
             self._selected = []
             value = ""

--- a/imas_paraview/plugins/base_class.py
+++ b/imas_paraview/plugins/base_class.py
@@ -148,6 +148,9 @@ class GGDVTKPluginBase(VTKPythonAlgorithmBase, ABC):
             if self._dbentry is not None:
                 self._dbentry.close()
                 self._ids = self._dbentry = None
+                self._selectable = []
+                self._selected = []
+                self._ids_list = []
             self._uri_error = ""
             if self._uri:
                 # Try to open the DBEntry
@@ -156,9 +159,6 @@ class GGDVTKPluginBase(VTKPythonAlgorithmBase, ABC):
                     logger.info(f'Successfully opened URI "{self._uri}".')
                 except Exception as exc:
                     self._uri_error = str(exc)
-                    self._selectable = []
-                    self._selected = []
-                    self._ids_list = []
             self._update_ids_list()
             self.Modified()
 
@@ -281,7 +281,7 @@ class GGDVTKPluginBase(VTKPythonAlgorithmBase, ABC):
         selecting a URI to load the Data Entry), or when the loaded Data Entry contains
         no IDSs supported by this plugin.
         """
-        if value == "<Select IDS>":
+        if value not in self._ids_list or value == "<Select IDS>":
             self._selectable = []
             self._selected = []
             value = ""


### PR DESCRIPTION
Skipping the check fixes #16: when restoring ParaView state, the IDS and Occurrence parameter was restored before all URI parameters. Skipping this check has fixed the issue.

I didn't observe any adverse side effects while testing, but we should keep an eye out for any.