### PR TITLE
Dynamically load GGD arrays

### DIFF
--- a/imas_paraview/io/read_ps.py
+++ b/imas_paraview/io/read_ps.py
@@ -320,22 +320,13 @@ class PlasmaStateReader:
 
         # Only add the components that have data:
         components = dict()  # name and values
-        for component_name in [
-            "radial",
-            "diamagnetic",
-            "parallel",
-            "poloidal",
-            "toroidal",
-            "r",
-            "phi",
-            "z",
-        ]:
-            try:
-                values = getattr(aos_vector_node[subset_idx], component_name)
-            except (IndexError, AttributeError):
-                continue
-            if len(values):
-                components[component_name] = values
+
+        # Search for filled 1D vector components
+        for component in aos_vector_node[subset_idx]:
+            metadata = component.metadata
+            if metadata.data_type == IDSDataType.FLT and metadata.ndim == 1:
+                if len(component):
+                    components[metadata.name] = component.value
 
         vtk_arr = vtkDoubleArray()
         vtk_arr.SetName(name)

--- a/imas_paraview/io/read_ps.py
+++ b/imas_paraview/io/read_ps.py
@@ -327,6 +327,7 @@ class PlasmaStateReader:
             "poloidal",
             "toroidal",
             "r",
+            "phi",
             "z",
         ]:
             try:


### PR DESCRIPTION
The `phi` [GGD quantity](https://imas-data-dictionary.readthedocs.io/en/latest/generated/ids/wall.html#wall-description_ggd-ggd-j_total-phi) was renamed from `toroidal` in DD version 3.42.0. As the GGD vectors are not dynamically searched for, `phi` was not being loaded. 

The loading of GGD vectors was changed such that it loads all filled FLT 1D arrays that it encounters instead, so that this does not happen in the future.