### PR TITLE
Add support for heterogeneous time in GGD readers (incl. JOREK)

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -3,7 +3,7 @@
 
 # You can set these variables from the command line, and also
 # from the environment for the first two.
-SPHINXOPTS    ?=
+SPHINXOPTS    ?= -W
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = source
 GENERATEDDIR  = $(SOURCEDIR)/generated

--- a/imas_paraview/convert.py
+++ b/imas_paraview/convert.py
@@ -95,10 +95,12 @@ class Converter:
 
         self.progress = progress
 
-        if self.time_idx is None:
+        if self.time_idx is None or not (0 <= self.time_idx < len(self.ids.time)):
             return None
+        if time is None:
+            time = self.ids.time[self.time_idx]
 
-        self.grid_ggd = get_grid_ggd(self.ids, self.time_idx, parent_idx)
+        self.grid_ggd = get_grid_ggd(self.ids, time, parent_idx)
         if self.grid_ggd is None:
             logger.warning("Could not load a valid GGD grid.")
             return None

--- a/imas_paraview/plugins/base_class.py
+++ b/imas_paraview/plugins/base_class.py
@@ -6,6 +6,11 @@ from abc import ABC, abstractmethod
 
 import imas
 import imas.ids_defs
+from imas.ids_defs import (
+    IDS_TIME_MODE_HETEROGENEOUS,
+    IDS_TIME_MODE_HOMOGENEOUS,
+    IDS_TIME_MODE_INDEPENDENT,
+)
 from paraview.util.vtkAlgorithm import smdomain, smhint, smproperty
 from vtkmodules.util.vtkAlgorithm import VTKPythonAlgorithmBase
 from vtkmodules.vtkCommonCore import vtkStringArray
@@ -510,15 +515,21 @@ class GGDVTKPluginBase(VTKPythonAlgorithmBase, ABC):
         # selectables are selected:
         self._selected = [item for item in self._selected if item in self._selectable]
 
-        # TODO: Add support for IDSs with heterogeneous time mode
         if self.is_time_dependent:
-            if (
-                self._ids.ids_properties.homogeneous_time
-                == imas.ids_defs.IDS_TIME_MODE_HETEROGENEOUS
-            ):
-                logger.error("Heterogeneous IDSs are currently not supported.")
-                return 1
-            self._time_steps = self._ids.time
+            time_mode = self._ids.ids_properties.homogeneous_time
+            if time_mode == IDS_TIME_MODE_INDEPENDENT:
+                # This IDS doesn't contain time-dependent data
+                self._time_steps = []
+            elif time_mode == IDS_TIME_MODE_HETEROGENEOUS:
+                # We need to ask the subclass implementation which time array to look at
+                self._time_steps = self.get_heterogeneous_time_array()
+            else:
+                if time_mode != IDS_TIME_MODE_HOMOGENEOUS:
+                    logger.warning(
+                        "Unexpected ids_properties.homogeneous_time: %i", time_mode
+                    )
+                # Use root time array
+                self._time_steps = self._ids.time
 
             # Pass time steps to Paraview
             executive = self.GetExecutive()
@@ -526,10 +537,11 @@ class GGDVTKPluginBase(VTKPythonAlgorithmBase, ABC):
             outInfo.Remove(executive.TIME_STEPS())
             outInfo.Remove(executive.TIME_RANGE())
 
-            for time_step in self._time_steps:
-                outInfo.Append(executive.TIME_STEPS(), time_step)
-            outInfo.Append(executive.TIME_RANGE(), self._time_steps[0])
-            outInfo.Append(executive.TIME_RANGE(), self._time_steps[-1])
+            if self._time_steps:
+                for time_step in self._time_steps:
+                    outInfo.Append(executive.TIME_STEPS(), time_step)
+                outInfo.Append(executive.TIME_RANGE(), self._time_steps[0])
+                outInfo.Append(executive.TIME_RANGE(), self._time_steps[-1])
         return 1
 
     def _load_ids_from_backend(self):
@@ -554,6 +566,14 @@ class GGDVTKPluginBase(VTKPythonAlgorithmBase, ABC):
             )
             self.setup_ids()
             self.converter = Converter(self._ids, dbentry=self._dbentry)
+
+    @abstractmethod
+    def get_heterogeneous_time_array(self):
+        """Return the time array when the IDS uses heterogeneous time."""
+        raise NotImplementedError(
+            "The IDS uses heterogeneous time mode, which is not implemented for this "
+            "reader."
+        )
 
     def request_information(self):
         """

--- a/imas_paraview/plugins/ggd_base_reader.py
+++ b/imas_paraview/plugins/ggd_base_reader.py
@@ -76,6 +76,17 @@ class GGDBaseReader(GGDVTKPluginBase):
             else:
                 self._selectable = self.filled_paths
 
+    def get_heterogeneous_time_array(self):
+        if self._ids.time.has_value:
+            # Assume main time array is the one we need
+            # This works for the data looked at until now (produced by JOREK).
+            # The DD allows way more complex cases, which could be implemented as well
+            # if such a case arises in the future.
+            return self._ids.time
+        raise NotImplementedError(
+            "Heterogeneous time mode with an empty time array is not implemented."
+        )
+
     def setup_ids(self):
         """
         Initializes plasma state reader and populates scalar and vector paths for

--- a/imas_paraview/tests/test_convert.py
+++ b/imas_paraview/tests/test_convert.py
@@ -1,11 +1,11 @@
 import imas
 import pytest
-from imas.ids_defs import IDS_TIME_MODE_HOMOGENEOUS
+from imas.ids_defs import IDS_TIME_MODE_HOMOGENEOUS, IDS_TIME_MODE_HETEROGENEOUS
 from imas.ids_path import IDSPath
 
 from imas_paraview.convert import Converter
 from imas_paraview.io.read_ps import PlasmaStateReader
-from imas_paraview.tests.fill_ggd import fill_ids
+from imas_paraview.tests.fill_ggd import fill_ids, fill_NxN_grid, fill_scalar_quantity
 from imas_paraview.util import get_grid_ggd
 
 
@@ -77,6 +77,35 @@ def test_ggd_to_vtk_out_of_bounds(dummy_ids_five_steps):
     converter = Converter(dummy_ids_five_steps)
     vtk_object = converter.ggd_to_vtk(time_idx=time_idx)
     assert vtk_object is None
+
+
+def test_ggd_to_vtk_heterogeneous():
+    ids = imas.IDSFactory(version="3.41.0").new("edge_profiles")
+    ids.ids_properties.homogeneous_time = IDS_TIME_MODE_HETEROGENEOUS
+    # 5 data points, two grids:
+    ids.time = [0.0, 0.1, 0.2, 0.3, 0.4]
+    ids.ggd.resize(5)
+    for ggd, time in zip(ids.ggd, ids.time):
+        ggd.time = time
+
+    ids.grid_ggd.resize(2)
+    ids.grid_ggd[0].time = 0
+    ids.grid_ggd[1].time = 0.2
+
+    num_vertices, num_edges, num_faces = fill_NxN_grid(ids.grid_ggd[0], 2)
+    for i in range(2):
+        fill_scalar_quantity(ids.ggd[i].zeff, num_vertices, num_edges, num_faces)
+    num_vertices, num_edges, num_faces = fill_NxN_grid(ids.grid_ggd[1], 3)
+    for i in range(2, 5):
+        fill_scalar_quantity(ids.ggd[i].zeff, num_vertices, num_edges, num_faces)
+
+    converter = Converter(ids)
+    for i in range(5):
+        vtk_object = converter.ggd_to_vtk(time_idx=i)
+        assert vtk_object is not None
+
+        num_faces = vtk_object.GetPartition(2, 0).GetNumberOfCells()
+        assert num_faces == (1 if i < 2 else 4)
 
 
 def test_ggd_to_vtk_subset():

--- a/imas_paraview/util.py
+++ b/imas_paraview/util.py
@@ -55,7 +55,7 @@ def get_ggd_path(ids_metadata) -> Optional[str]:
     return None
 
 
-def get_grid_ggd(ids, ggd_idx=0, parent_idx=0):
+def get_grid_ggd(ids, time=0, parent_idx=0):
     """Finds and returns the grid_ggd within IDS at the time index ggd_idx. If the
     grid_ggd at ggd_idx time index does not exist, it tries to return the first
     grid_ggd. If this does not exist, it returns None.
@@ -81,6 +81,11 @@ def get_grid_ggd(ids, ggd_idx=0, parent_idx=0):
             pass  # Current node is a structure
         elif node.metadata.coordinate1.is_time_coordinate:
             # Time dependent array of structure
+            # Let IMAS-Python handle the time mode (homogeneous/heterogeneous):
+            time_array = node.coordinates[0]
+            # Load closest previous time index
+            ggd_idx = np.searchsorted(time_array, time, side="right") - 1
+
             if 0 <= ggd_idx < len(node):
                 node = node[ggd_idx]
             else:

--- a/imas_paraview/util.py
+++ b/imas_paraview/util.py
@@ -62,7 +62,7 @@ def get_grid_ggd(ids, time=0, parent_idx=0):
 
     Args:
         ids: The IDS for which to return the grid_gdd.
-        ggd_idx: Time index for which to load the grid.
+        time: Time value for which to load the grid.
         parent_idx: Index for any non-time-dependent parent Array of Structures.
             For example ``description_ggd[parent_idx].grid_ggd[ggd_idx]`` in the wall
             IDS.


### PR DESCRIPTION
Tested successfully with heterogeneous time JOREK disruption dataset: `imas:hdf5?user=public;pulse=113111;run=3;database=ITER_DISRUPTIONS;version=4` 