### PR TITLE
Add tests with real IDS data

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,12 +108,14 @@ jobs:
         key: ${{ steps.cache-paraview.outputs.cache-primary-key }}
         path: paraview/
 
-    - name: Install dependencies
-      run: |
-        # Install dependencies required for running paraview gui in xfvb-run:
-        sudo apt update
-        sudo apt install -y libqt5gui5-gles
+    - name: Cache and Install Dependencies
+      uses: awalsh128/cache-apt-pkgs-action@latest
+      with:
+        packages: libqt5gui5-gles
+        version: 1.0
 
+    - name: Install Python dependencies
+      run: |
         # Install python dependencies
         python -m venv venv
         . venv/bin/activate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on: push
 
 env:
-  # Zenodo record ID for test datasets
+  # Zenodo record IDs for test datasets
   ZENODO_MD_ID: 17113713
   ZENODO_SCENARIOS_ID: 17062700
 
@@ -70,14 +70,14 @@ jobs:
         key=$(echo "${urls[*]}" | sha256sum | cut -d ' ' -f1)
         echo "key=${key}" >> $GITHUB_OUTPUT
 
-    - name: Restore Zenodo datasets from cache
-      id: cache-datasets-restore
-      uses: actions/cache/restore@v4
+    - name: Cache Zenodo datasets
+      id: cache-datasets
+      uses: actions/cache@v4
       with:
         path: data
         key: ${{ steps.datasets.outputs.key }}
 
-    - if: ${{ steps.cache-datasets-restore.outputs.cache-hit != 'true' }}
+    - if: ${{ steps.cache-datasets.outputs.cache-hit != 'true' }}
       name: Download datasets if not cached
       run: |
         mkdir -p data
@@ -85,13 +85,6 @@ jobs:
           echo "Downloading $(basename $url) ..."
           wget -P data/ "$url"
         done
-
-    - if: ${{ steps.cache-datasets-restore.outputs.cache-hit != 'true' }}
-      name: Save Zenodo datasets to cache
-      uses: actions/cache/save@v4
-      with:
-        path: data
-        key: ${{ steps.datasets.outputs.key }}      
         
     - name: Cache paraview
       id: cache-paraview

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,11 +2,6 @@ name: CI
 
 on: push
 
-env:
-  # Zenodo record IDs for test datasets
-  ZENODO_MD_ID: 17113713
-  ZENODO_SCENARIOS_ID: 17062700
-
 jobs:
   linting:
     runs-on: ubuntu-latest
@@ -54,15 +49,15 @@ jobs:
       id: datasets
       run: |
         urls=(
-          https://zenodo.org/record/${ZENODO_SCENARIOS_ID}/files/iter_disruption_113112_1.nc
-          https://zenodo.org/record/${ZENODO_SCENARIOS_ID}/files/iter_scenario_123364_1.nc
-          https://zenodo.org/record/${ZENODO_SCENARIOS_ID}/files/iter_scenario_53298_seq1_DD4.nc
-          https://zenodo.org/record/${ZENODO_MD_ID}/files/iter_md_bolometer_150401_3.nc
-          https://zenodo.org/record/${ZENODO_MD_ID}/files/iter_md_ec_launchers_120000_1304.nc
-          https://zenodo.org/record/${ZENODO_MD_ID}/files/iter_md_ece_150601_22.nc
-          https://zenodo.org/record/${ZENODO_MD_ID}/files/iter_md_magnetics_150100_5.nc
-          https://zenodo.org/record/${ZENODO_MD_ID}/files/iter_md_wall_116000_5.nc
-          https://zenodo.org/record/${ZENODO_MD_ID}/files/iter_md_wall_116100_2001.nc
+          https://zenodo.org/record/17062700/files/iter_disruption_113112_1.nc
+          https://zenodo.org/record/17062700/files/iter_scenario_123364_1.nc
+          https://zenodo.org/record/17062700/files/iter_scenario_53298_seq1_DD4.nc
+          https://zenodo.org/record/17113713/files/iter_md_bolometer_150401_3.nc
+          https://zenodo.org/record/17113713/files/iter_md_ec_launchers_120000_1304.nc
+          https://zenodo.org/record/17113713/files/iter_md_ece_150601_22.nc
+          https://zenodo.org/record/17113713/files/iter_md_magnetics_150100_5.nc
+          https://zenodo.org/record/17113713/files/iter_md_wall_116000_5.nc
+          https://zenodo.org/record/17113713/files/iter_md_wall_116100_2001.nc
         )
         echo "files=${urls[*]}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,49 @@ jobs:
         python-version: '3.10'
         cache: 'pip'  # caching pip dependencies
 
+    - name: Define dataset list and cache key
+      id: datasets
+      run: |
+        urls=(
+          https://zenodo.org/record/17062700/files/iter_disruption_113112_1.nc
+          https://zenodo.org/record/17062700/files/iter_scenario_123364_1.nc
+          https://zenodo.org/record/17062700/files/iter_scenario_53298_seq1_DD4.nc
+          https://zenodo.org/record/15525525/files/iter_md_bolometer_150401_3.nc
+          https://zenodo.org/record/15525525/files/iter_md_ec_launchers_120000_1304.nc
+          https://zenodo.org/record/15525525/files/iter_md_ece_150601_22.nc
+          https://zenodo.org/record/15525525/files/iter_md_magnetics_150100_5.nc
+          https://zenodo.org/record/15525525/files/iter_md_wall_116000_5.nc
+          https://zenodo.org/record/15525525/files/iter_md_wall_116100_2001.nc
+        )
+        echo "files=${urls[*]}" >> $GITHUB_OUTPUT
+
+        # Generate a hash key from the URLs list, this is used for caching
+        key=$(echo "${urls[*]}" | sha256sum | cut -d ' ' -f1)
+        echo "key=${key}" >> $GITHUB_OUTPUT
+
+    - name: Restore Zenodo datasets from cache
+      id: cache-datasets-restore
+      uses: actions/cache/restore@v4
+      with:
+        path: data
+        key: ${{ steps.datasets.outputs.key }}
+
+    - if: ${{ steps.cache-datasets-restore.outputs.cache-hit != 'true' }}
+      name: Download datasets if not cached
+      run: |
+        mkdir -p data
+        for url in ${{ steps.datasets.outputs.files }}; do
+          echo "Downloading $(basename $url) ..."
+          wget -P data/ "$url"
+        done
+
+    - if: ${{ steps.cache-datasets-restore.outputs.cache-hit != 'true' }}
+      name: Save Zenodo datasets to cache
+      uses: actions/cache/save@v4
+      with:
+        path: data
+        key: ${{ steps.datasets.outputs.key }}      
+        
     - name: Cache paraview
       id: cache-paraview
       uses: actions/cache/restore@v4
@@ -70,6 +113,7 @@ jobs:
     - name: Install dependencies
       run: |
         # Install dependencies required for running paraview gui in xfvb-run:
+        sudo apt update
         sudo apt install -y libqt5gui5-gles
 
         # Install python dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,11 @@ name: CI
 
 on: push
 
+env:
+  # Zenodo record ID for test datasets
+  ZENODO_MD_ID: 17113713
+  ZENODO_SCENARIOS_ID: 17062700
+
 jobs:
   linting:
     runs-on: ubuntu-latest
@@ -49,15 +54,15 @@ jobs:
       id: datasets
       run: |
         urls=(
-          https://zenodo.org/record/17062700/files/iter_disruption_113112_1.nc
-          https://zenodo.org/record/17062700/files/iter_scenario_123364_1.nc
-          https://zenodo.org/record/17062700/files/iter_scenario_53298_seq1_DD4.nc
-          https://zenodo.org/record/15525525/files/iter_md_bolometer_150401_3.nc
-          https://zenodo.org/record/15525525/files/iter_md_ec_launchers_120000_1304.nc
-          https://zenodo.org/record/15525525/files/iter_md_ece_150601_22.nc
-          https://zenodo.org/record/15525525/files/iter_md_magnetics_150100_5.nc
-          https://zenodo.org/record/15525525/files/iter_md_wall_116000_5.nc
-          https://zenodo.org/record/15525525/files/iter_md_wall_116100_2001.nc
+          https://zenodo.org/record/${ZENODO_SCENARIOS_ID}/files/iter_disruption_113112_1.nc
+          https://zenodo.org/record/${ZENODO_SCENARIOS_ID}/files/iter_scenario_123364_1.nc
+          https://zenodo.org/record/${ZENODO_SCENARIOS_ID}/files/iter_scenario_53298_seq1_DD4.nc
+          https://zenodo.org/record/${ZENODO_MD_ID}/files/iter_md_bolometer_150401_3.nc
+          https://zenodo.org/record/${ZENODO_MD_ID}/files/iter_md_ec_launchers_120000_1304.nc
+          https://zenodo.org/record/${ZENODO_MD_ID}/files/iter_md_ece_150601_22.nc
+          https://zenodo.org/record/${ZENODO_MD_ID}/files/iter_md_magnetics_150100_5.nc
+          https://zenodo.org/record/${ZENODO_MD_ID}/files/iter_md_wall_116000_5.nc
+          https://zenodo.org/record/${ZENODO_MD_ID}/files/iter_md_wall_116100_2001.nc
         )
         echo "files=${urls[*]}" >> $GITHUB_OUTPUT
 

--- a/imas_paraview/tests/conftest.py
+++ b/imas_paraview/tests/conftest.py
@@ -9,8 +9,12 @@ import pytest
 from imas_paraview.plugins.vtkggdreader import SUPPORTED_IDS_NAMES
 from imas_paraview.tests.fill_ggd import fill_ids
 
-
 logger = logging.getLogger("imas_paraview")
+
+
+@pytest.fixture()
+def test_data_dir():
+    return Path("/home/ITER/blokhus/public/imas_paraview_tests")
 
 
 def set_environment():

--- a/imas_paraview/tests/conftest.py
+++ b/imas_paraview/tests/conftest.py
@@ -14,7 +14,7 @@ logger = logging.getLogger("imas_paraview")
 
 @pytest.fixture()
 def test_data_dir():
-    return Path("/home/ITER/blokhus/public/imas_paraview_tests")
+    return Path("data/")
 
 
 def set_environment():

--- a/imas_paraview/tests/integration_tests/xml_integration_tests/profiles_1d_mapper.xml
+++ b/imas_paraview/tests/integration_tests/xml_integration_tests/profiles_1d_mapper.xml
@@ -3,14 +3,14 @@
   <pqevent object="pqClientMainWindow/menubar" command="activate" arguments="menuSources" />
   <pqevent object="pqClientMainWindow/menubar/menuSources" command="activate" arguments="IMAS Tools" />
   <pqevent object="pqClientMainWindow/menubar/menuSources/IMAS Tools" command="activate" arguments="JOREK Reader" />
-  <pqevent object="pqClientMainWindow/propertiesDock/propertiesPanel/scrollArea/qt_scrollarea_viewport/scrollAreaWidgetContents/PropertiesFrame/ProxyPanel/EnterURI/Enter URI" command="set_string" arguments="/home/ITER/blokhus/public/imas_paraview_tests/iter_dis-112111-2.nc" />
+  <pqevent object="pqClientMainWindow/propertiesDock/propertiesPanel/scrollArea/qt_scrollarea_viewport/scrollAreaWidgetContents/PropertiesFrame/ProxyPanel/EnterURI/Enter URI" command="set_string" arguments="imas:mdsplus?user=artolaj;pulse=200000;run=1;database=JOREK_disruptions;version=3" />
   <pqevent object="pqClientMainWindow/propertiesDock/propertiesPanel/Accept" command="activate" arguments="" />
   <pqevent object="pqClientMainWindow/propertiesDock/propertiesPanel/scrollArea/qt_scrollarea_viewport/scrollAreaWidgetContents/PropertiesFrame/ProxyPanel/AttributeArraySelector/ArraySelectionWidget" command="setCheckState" arguments="4.0,2" />
   <pqevent object="pqClientMainWindow/propertiesDock/propertiesPanel/Accept" command="activate" arguments="" />
   <pqevent object="pqClientMainWindow/menubar" command="activate" arguments="menuSources" />
   <pqevent object="pqClientMainWindow/menubar/menuSources" command="activate" arguments="IMAS Tools" />
   <pqevent object="pqClientMainWindow/menubar/menuSources/IMAS Tools" command="activate" arguments="Profiles1DReader" />
-  <pqevent object="pqClientMainWindow/propertiesDock/propertiesPanel/scrollArea/qt_scrollarea_viewport/scrollAreaWidgetContents/PropertiesFrame/ProxyPanel/EnterURI/Enter URI" command="set_string" arguments="/home/ITER/blokhus/public/imas_paraview_tests/iter_dis-112111-2.nc" />
+  <pqevent object="pqClientMainWindow/propertiesDock/propertiesPanel/scrollArea/qt_scrollarea_viewport/scrollAreaWidgetContents/PropertiesFrame/ProxyPanel/EnterURI/Enter URI" command="set_string" arguments="imas:hdf5?path=/work/imas/shared/imasdb/ITER_SCENARIOS/3/134102/41" />
   <pqevent object="pqClientMainWindow/propertiesDock/propertiesPanel/Accept" command="activate" arguments="" />
   <pqevent object="pqClientMainWindow/centralwidget/MultiViewWidget/CoreWidget/qt_tabwidget_stackedwidget/MultiViewWidget1/Container/Frame.2/Close" command="activate" arguments="" />
   <pqevent object="pqClientMainWindow/propertiesDock/propertiesPanel/scrollArea/qt_scrollarea_viewport/scrollAreaWidgetContents/PropertiesFrame/ProxyPanel/IDSAndOccurrence/ComboBox" command="activated" arguments="core_profiles" />

--- a/imas_paraview/tests/integration_tests/xml_integration_tests/profiles_1d_mapper.xml
+++ b/imas_paraview/tests/integration_tests/xml_integration_tests/profiles_1d_mapper.xml
@@ -3,14 +3,14 @@
   <pqevent object="pqClientMainWindow/menubar" command="activate" arguments="menuSources" />
   <pqevent object="pqClientMainWindow/menubar/menuSources" command="activate" arguments="IMAS Tools" />
   <pqevent object="pqClientMainWindow/menubar/menuSources/IMAS Tools" command="activate" arguments="JOREK Reader" />
-  <pqevent object="pqClientMainWindow/propertiesDock/propertiesPanel/scrollArea/qt_scrollarea_viewport/scrollAreaWidgetContents/PropertiesFrame/ProxyPanel/EnterURI/Enter URI" command="set_string" arguments="imas:mdsplus?user=artolaj;pulse=200000;run=1;database=JOREK_disruptions;version=3" />
+  <pqevent object="pqClientMainWindow/propertiesDock/propertiesPanel/scrollArea/qt_scrollarea_viewport/scrollAreaWidgetContents/PropertiesFrame/ProxyPanel/EnterURI/Enter URI" command="set_string" arguments="/home/ITER/blokhus/public/imas_paraview_tests/iter_dis-112111-2.nc" />
   <pqevent object="pqClientMainWindow/propertiesDock/propertiesPanel/Accept" command="activate" arguments="" />
   <pqevent object="pqClientMainWindow/propertiesDock/propertiesPanel/scrollArea/qt_scrollarea_viewport/scrollAreaWidgetContents/PropertiesFrame/ProxyPanel/AttributeArraySelector/ArraySelectionWidget" command="setCheckState" arguments="4.0,2" />
   <pqevent object="pqClientMainWindow/propertiesDock/propertiesPanel/Accept" command="activate" arguments="" />
   <pqevent object="pqClientMainWindow/menubar" command="activate" arguments="menuSources" />
   <pqevent object="pqClientMainWindow/menubar/menuSources" command="activate" arguments="IMAS Tools" />
   <pqevent object="pqClientMainWindow/menubar/menuSources/IMAS Tools" command="activate" arguments="Profiles1DReader" />
-  <pqevent object="pqClientMainWindow/propertiesDock/propertiesPanel/scrollArea/qt_scrollarea_viewport/scrollAreaWidgetContents/PropertiesFrame/ProxyPanel/EnterURI/Enter URI" command="set_string" arguments="imas:hdf5?path=/work/imas/shared/imasdb/ITER_SCENARIOS/3/134102/41" />
+  <pqevent object="pqClientMainWindow/propertiesDock/propertiesPanel/scrollArea/qt_scrollarea_viewport/scrollAreaWidgetContents/PropertiesFrame/ProxyPanel/EnterURI/Enter URI" command="set_string" arguments="/home/ITER/blokhus/public/imas_paraview_tests/iter_dis-112111-2.nc" />
   <pqevent object="pqClientMainWindow/propertiesDock/propertiesPanel/Accept" command="activate" arguments="" />
   <pqevent object="pqClientMainWindow/centralwidget/MultiViewWidget/CoreWidget/qt_tabwidget_stackedwidget/MultiViewWidget1/Container/Frame.2/Close" command="activate" arguments="" />
   <pqevent object="pqClientMainWindow/propertiesDock/propertiesPanel/scrollArea/qt_scrollarea_viewport/scrollAreaWidgetContents/PropertiesFrame/ProxyPanel/IDSAndOccurrence/ComboBox" command="activated" arguments="core_profiles" />

--- a/imas_paraview/tests/test_beam.py
+++ b/imas_paraview/tests/test_beam.py
@@ -8,9 +8,9 @@ def test_load_beam():
     """Test if limiters are loaded in the VTK Multiblock Dataset."""
     reader = BeamReader()
     with DBEntry(
-        "/home/ITER/blokhus/public/imas_paraview_tests/ec_launchers.nc", "r"
+        "/home/ITER/blokhus/public/imas_paraview_tests/iter_md-120000-1304.nc", "r"
     ) as entry:
-        ids = entry.get("ec_launchers", lazy=True, autoconvert=False)
+        ids = entry.get("ec_launchers", autoconvert=False)
         reader._ids = ids
         reader.setup_ids()
         time_idx = 0

--- a/imas_paraview/tests/test_beam.py
+++ b/imas_paraview/tests/test_beam.py
@@ -7,7 +7,7 @@ from imas_paraview.plugins.beam import BeamReader
 def test_load_beam(test_data_dir):
     """Test if limiters are loaded in the VTK Multiblock Dataset."""
     reader = BeamReader()
-    with DBEntry(test_data_dir / "iter_md-120000-1304.nc", "r") as entry:
+    with DBEntry(test_data_dir / "iter_md_ec_launchers_120000_1304.nc", "r") as entry:
         ids = entry.get("ec_launchers", autoconvert=False)
         reader._ids = ids
         reader.setup_ids()

--- a/imas_paraview/tests/test_beam.py
+++ b/imas_paraview/tests/test_beam.py
@@ -4,12 +4,10 @@ from vtkmodules.vtkCommonDataModel import vtkMultiBlockDataSet
 from imas_paraview.plugins.beam import BeamReader
 
 
-def test_load_beam():
+def test_load_beam(test_data_dir):
     """Test if limiters are loaded in the VTK Multiblock Dataset."""
     reader = BeamReader()
-    with DBEntry(
-        "/home/ITER/blokhus/public/imas_paraview_tests/iter_md-120000-1304.nc", "r"
-    ) as entry:
+    with DBEntry(test_data_dir / "iter_md-120000-1304.nc", "r") as entry:
         ids = entry.get("ec_launchers", autoconvert=False)
         reader._ids = ids
         reader.setup_ids()

--- a/imas_paraview/tests/test_beam.py
+++ b/imas_paraview/tests/test_beam.py
@@ -1,20 +1,14 @@
-import pytest
 from imas import DBEntry
 from vtkmodules.vtkCommonDataModel import vtkMultiBlockDataSet
 
 from imas_paraview.plugins.beam import BeamReader
 
 
-@pytest.mark.skip(reason="no IMAS-Core available")
 def test_load_beam():
     """Test if limiters are loaded in the VTK Multiblock Dataset."""
     reader = BeamReader()
     with DBEntry(
-        (
-            "imas:hdf5?path=/work/imas/shared/imasdb/ITER_MACHINE_DESCRIPTION/"
-            "3/120000/1304/"
-        ),
-        "r",
+        "/home/ITER/blokhus/public/imas_paraview_tests/ec_launchers.nc", "r"
     ) as entry:
         ids = entry.get("ec_launchers", lazy=True, autoconvert=False)
         reader._ids = ids

--- a/imas_paraview/tests/test_convert.py
+++ b/imas_paraview/tests/test_convert.py
@@ -145,7 +145,7 @@ def test_ggd_to_vtk_subset_time_index(dummy_ids_five_steps):
 
 
 def test_ggd_to_vtk_solps(test_data_dir):
-    with DBEntry(test_data_dir / "iter_db-123364-1.nc", "r") as entry:
+    with DBEntry(test_data_dir / "iter_scenario_123364_1.nc", "r") as entry:
         ids = entry.get("edge_profiles", autoconvert=False)
         converter = Converter(ids)
         vtk_object = converter.ggd_to_vtk()
@@ -177,8 +177,8 @@ def test_ggd_to_vtk_solps(test_data_dir):
 
 
 def test_ggd_to_vtk_jorek(test_data_dir):
-    with DBEntry(test_data_dir / "iter_dis-113112-1.nc", "r") as entry:
-        ids = entry.get("plasma_profiles", autoconvert=False)
+    with DBEntry(test_data_dir / "iter_disruption_113112_1.nc", "r") as entry:
+        ids = entry.get("plasma_profiles", autoconvert=False, occurrence=1)
         converter = Converter(ids)
 
         plane_config = InterpSettings(n_plane=3, phi_start=0, phi_end=180)

--- a/imas_paraview/tests/test_convert.py
+++ b/imas_paraview/tests/test_convert.py
@@ -7,7 +7,7 @@ from imas.ids_defs import IDS_TIME_MODE_HETEROGENEOUS, IDS_TIME_MODE_HOMOGENEOUS
 from imas.ids_path import IDSPath
 from vtk.util.numpy_support import vtk_to_numpy
 
-from imas_paraview.convert import Converter
+from imas_paraview.convert import Converter, InterpSettings
 from imas_paraview.io.read_ps import PlasmaStateReader
 from imas_paraview.tests.fill_ggd import fill_ids, fill_NxN_grid, fill_scalar_quantity
 from imas_paraview.util import get_grid_ggd
@@ -176,6 +176,23 @@ def test_ggd_to_vtk_solps():
         np_vtk_face = vtk_to_numpy(vtk_face_array)
         elec_temp_face = ids.ggd[0].electrons.temperature[4].values
         assert np.array_equal(elec_temp_face, np_vtk_face)
+
+
+def test_ggd_to_vtk_jorek():
+    with DBEntry(
+        "/home/ITER/blokhus/public/imas_paraview_tests/iter_dis-113112-1.nc", "r"
+    ) as entry:
+        ids = entry.get("plasma_profiles", autoconvert=False)
+        converter = Converter(ids)
+
+        plane_config = InterpSettings(n_plane=3, phi_start=0, phi_end=180)
+        for t in range(3):
+            vtk_object = converter.ggd_to_vtk(time_idx=t, plane_config=plane_config)
+            pd = vtk_object.GetPartitionedDataSet(0)
+            vtk_grid = pd.GetPartition(0)
+            vtk_point_data = vtk_grid.GetPointData()
+            vtk_elec = vtk_point_data.GetArray("Electrons Temperature [eV]")
+            assert vtk_elec is not None
 
 
 def assert_cache(converter, hits, misses):

--- a/imas_paraview/tests/test_convert.py
+++ b/imas_paraview/tests/test_convert.py
@@ -1,7 +1,11 @@
 import imas
+import numpy as np
 import pytest
-from imas.ids_defs import IDS_TIME_MODE_HOMOGENEOUS, IDS_TIME_MODE_HETEROGENEOUS
+import vtk
+from imas import DBEntry
+from imas.ids_defs import IDS_TIME_MODE_HETEROGENEOUS, IDS_TIME_MODE_HOMOGENEOUS
 from imas.ids_path import IDSPath
+from vtk.util.numpy_support import vtk_to_numpy
 
 from imas_paraview.convert import Converter
 from imas_paraview.io.read_ps import PlasmaStateReader
@@ -138,6 +142,40 @@ def test_ggd_to_vtk_subset_time_index(dummy_ids_five_steps):
     converter = Converter(dummy_ids_five_steps)
     vtk_object = converter.ggd_to_vtk(time=5, time_idx=6)
     assert vtk_object is None
+
+
+def test_ggd_to_vtk_solps():
+    with DBEntry(
+        "/home/ITER/blokhus/public/imas_paraview_tests/iter_db-123364-1.nc", "r"
+    ) as entry:
+        ids = entry.get("edge_profiles", autoconvert=False)
+        converter = Converter(ids)
+        vtk_object = converter.ggd_to_vtk()
+        num_pds = vtk_object.GetNumberOfPartitionedDataSets()
+        grid_subsets = ids.grid_ggd[0].grid_subset
+        assert num_pds == len(grid_subsets)
+        # Check if names of subsets match partition names
+        for i in range(num_pds):
+            name = vtk_object.GetMetaData(i).Get(vtk.vtkCompositeDataSet.NAME())
+            assert name == grid_subsets[i].identifier.name
+
+        # Check points array
+        pd = vtk_object.GetPartitionedDataSet(0)
+        vtk_grid = pd.GetPartition(0)
+        vtk_point_data = vtk_grid.GetPointData()
+        elec_temp = ids.ggd[0].electrons.temperature[0].values
+        vtk_elec = vtk_point_data.GetArray("Electrons Temperature [eV]")
+        np_vtk_elec = vtk_to_numpy(vtk_elec)
+        assert np.array_equal(elec_temp, np_vtk_elec)
+
+        # Check cells array
+        pd = vtk_object.GetPartitionedDataSet(4)
+        vtk_grid = pd.GetPartition(0)
+        vtk_face_data = vtk_grid.GetCellData()
+        vtk_face_array = vtk_face_data.GetArray("Electrons Temperature [eV]")
+        np_vtk_face = vtk_to_numpy(vtk_face_array)
+        elec_temp_face = ids.ggd[0].electrons.temperature[4].values
+        assert np.array_equal(elec_temp_face, np_vtk_face)
 
 
 def assert_cache(converter, hits, misses):

--- a/imas_paraview/tests/test_convert.py
+++ b/imas_paraview/tests/test_convert.py
@@ -144,10 +144,8 @@ def test_ggd_to_vtk_subset_time_index(dummy_ids_five_steps):
     assert vtk_object is None
 
 
-def test_ggd_to_vtk_solps():
-    with DBEntry(
-        "/home/ITER/blokhus/public/imas_paraview_tests/iter_db-123364-1.nc", "r"
-    ) as entry:
+def test_ggd_to_vtk_solps(test_data_dir):
+    with DBEntry(test_data_dir / "iter_db-123364-1.nc", "r") as entry:
         ids = entry.get("edge_profiles", autoconvert=False)
         converter = Converter(ids)
         vtk_object = converter.ggd_to_vtk()
@@ -178,10 +176,8 @@ def test_ggd_to_vtk_solps():
         assert np.array_equal(elec_temp_face, np_vtk_face)
 
 
-def test_ggd_to_vtk_jorek():
-    with DBEntry(
-        "/home/ITER/blokhus/public/imas_paraview_tests/iter_dis-113112-1.nc", "r"
-    ) as entry:
+def test_ggd_to_vtk_jorek(test_data_dir):
+    with DBEntry(test_data_dir / "iter_dis-113112-1.nc", "r") as entry:
         ids = entry.get("plasma_profiles", autoconvert=False)
         converter = Converter(ids)
 

--- a/imas_paraview/tests/test_line_of_sight.py
+++ b/imas_paraview/tests/test_line_of_sight.py
@@ -12,9 +12,9 @@ def test_load_los():
     reader = LineOfSightReader()
 
     with DBEntry(
-        "/home/ITER/blokhus/public/imas_paraview_tests/bolometer.nc", "r"
+        "/home/ITER/blokhus/public/imas_paraview_tests/iter_md-150401-3.nc", "r"
     ) as entry:
-        ids = entry.get("bolometer", lazy=True, autoconvert=False)
+        ids = entry.get("bolometer", autoconvert=False)
         reader._ids = ids
         reader.setup_ids()
 
@@ -52,8 +52,10 @@ def test_load_los_ece():
     """Test if line_of_sight structures in ece are loaded in the VTK
     Multiblock Dataset."""
     reader = LineOfSightReader()
-    with DBEntry("/home/ITER/blokhus/public/imas_paraview_tests/ece.nc", "r") as entry:
-        ids = entry.get("ece", lazy=True, autoconvert=False)
+    with DBEntry(
+        "/home/ITER/blokhus/public/imas_paraview_tests/iter_md-150601-22.nc", "r"
+    ) as entry:
+        ids = entry.get("ece", autoconvert=False)
         reader._ids = ids
         reader.setup_ids()
 

--- a/imas_paraview/tests/test_line_of_sight.py
+++ b/imas_paraview/tests/test_line_of_sight.py
@@ -11,7 +11,7 @@ def test_load_los(test_data_dir):
     """Test if line_of_sight structures are loaded in the VTK Multiblock Dataset."""
     reader = LineOfSightReader()
 
-    with DBEntry(test_data_dir / "iter_md-150401-3.nc", "r") as entry:
+    with DBEntry(test_data_dir / "iter_md_bolometer_150401_3.nc", "r") as entry:
         ids = entry.get("bolometer", autoconvert=False)
         reader._ids = ids
         reader.setup_ids()
@@ -50,7 +50,7 @@ def test_load_los_ece(test_data_dir):
     """Test if line_of_sight structures in ece are loaded in the VTK
     Multiblock Dataset."""
     reader = LineOfSightReader()
-    with DBEntry(test_data_dir / "iter_md-150601-22.nc", "r") as entry:
+    with DBEntry(test_data_dir / "iter_md_ece_150601_22.nc", "r") as entry:
         ids = entry.get("ece", autoconvert=False)
         reader._ids = ids
         reader.setup_ids()

--- a/imas_paraview/tests/test_line_of_sight.py
+++ b/imas_paraview/tests/test_line_of_sight.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 from imas import DBEntry
 from vtk.util.numpy_support import vtk_to_numpy
 from vtkmodules.vtkCommonDataModel import vtkMultiBlockDataSet
@@ -8,14 +7,12 @@ from imas_paraview.plugins.line_of_sight import LineOfSightReader
 from imas_paraview.util import pol_to_cart
 
 
-@pytest.mark.skip(reason="no IMAS-Core available")
 def test_load_los():
     """Test if line_of_sight structures are loaded in the VTK Multiblock Dataset."""
     reader = LineOfSightReader()
 
     with DBEntry(
-        "imas:hdf5?path=/work/imas/shared/imasdb/ITER_MACHINE_DESCRIPTION/3/150401/3/",
-        "r",
+        "/home/ITER/blokhus/public/imas_paraview_tests/bolometer.nc", "r"
     ) as entry:
         ids = entry.get("bolometer", lazy=True, autoconvert=False)
         reader._ids = ids
@@ -51,15 +48,11 @@ def test_load_los():
             assert_values_match(los, output.GetBlock(i))
 
 
-@pytest.mark.skip(reason="no IMAS-Core available")
 def test_load_los_ece():
     """Test if line_of_sight structures in ece are loaded in the VTK
     Multiblock Dataset."""
     reader = LineOfSightReader()
-    with DBEntry(
-        "imas:hdf5?path=/work/imas/shared/imasdb/ITER_MACHINE_DESCRIPTION/3/150601/22",
-        "r",
-    ) as entry:
+    with DBEntry("/home/ITER/blokhus/public/imas_paraview_tests/ece.nc", "r") as entry:
         ids = entry.get("ece", lazy=True, autoconvert=False)
         reader._ids = ids
         reader.setup_ids()

--- a/imas_paraview/tests/test_line_of_sight.py
+++ b/imas_paraview/tests/test_line_of_sight.py
@@ -7,13 +7,11 @@ from imas_paraview.plugins.line_of_sight import LineOfSightReader
 from imas_paraview.util import pol_to_cart
 
 
-def test_load_los():
+def test_load_los(test_data_dir):
     """Test if line_of_sight structures are loaded in the VTK Multiblock Dataset."""
     reader = LineOfSightReader()
 
-    with DBEntry(
-        "/home/ITER/blokhus/public/imas_paraview_tests/iter_md-150401-3.nc", "r"
-    ) as entry:
+    with DBEntry(test_data_dir / "iter_md-150401-3.nc", "r") as entry:
         ids = entry.get("bolometer", autoconvert=False)
         reader._ids = ids
         reader.setup_ids()
@@ -48,13 +46,11 @@ def test_load_los():
             assert_values_match(los, output.GetBlock(i))
 
 
-def test_load_los_ece():
+def test_load_los_ece(test_data_dir):
     """Test if line_of_sight structures in ece are loaded in the VTK
     Multiblock Dataset."""
     reader = LineOfSightReader()
-    with DBEntry(
-        "/home/ITER/blokhus/public/imas_paraview_tests/iter_md-150601-22.nc", "r"
-    ) as entry:
+    with DBEntry(test_data_dir / "iter_md-150601-22.nc", "r") as entry:
         ids = entry.get("ece", autoconvert=False)
         reader._ids = ids
         reader.setup_ids()

--- a/imas_paraview/tests/test_position.py
+++ b/imas_paraview/tests/test_position.py
@@ -10,8 +10,10 @@ from imas_paraview.util import pol_to_cart
 def test_load_position_magnetics():
     """Test if positions of magnetics barometry IDS are saved into vtkPolyData."""
     reader = PositionReader()
-    entry = DBEntry("/home/ITER/blokhus/public/imas_paraview_tests/magnetics.nc", "r")
-    ids = entry.get("magnetics", lazy=True, autoconvert=False)
+    entry = DBEntry(
+        "/home/ITER/blokhus/public/imas_paraview_tests/iter_md-150100-5.nc", "r"
+    )
+    ids = entry.get("magnetics", autoconvert=False)
 
     reader._ids = ids
     reader.setup_ids()

--- a/imas_paraview/tests/test_position.py
+++ b/imas_paraview/tests/test_position.py
@@ -1,6 +1,5 @@
 import imas
 import numpy as np
-import pytest
 from imas import DBEntry
 from vtkmodules.vtkCommonDataModel import vtkPolyData
 
@@ -8,17 +7,10 @@ from imas_paraview.plugins.position import PositionReader
 from imas_paraview.util import pol_to_cart
 
 
-@pytest.mark.skip(reason="no IMAS-Core available")
 def test_load_position_magnetics():
     """Test if positions of magnetics barometry IDS are saved into vtkPolyData."""
     reader = PositionReader()
-    entry = DBEntry(
-        (
-            "imas:hdf5?path=/work/imas/shared/imasdb/ITER_MACHINE_DESCRIPTION/"
-            "/3/150100/5/"
-        ),
-        "r",
-    )
+    entry = DBEntry("/home/ITER/blokhus/public/imas_paraview_tests/magnetics.nc", "r")
     ids = entry.get("magnetics", lazy=True, autoconvert=False)
 
     reader._ids = ids

--- a/imas_paraview/tests/test_position.py
+++ b/imas_paraview/tests/test_position.py
@@ -10,7 +10,7 @@ from imas_paraview.util import pol_to_cart
 def test_load_position_magnetics(test_data_dir):
     """Test if positions of magnetics barometry IDS are saved into vtkPolyData."""
     reader = PositionReader()
-    entry = DBEntry(test_data_dir / "iter_md-150100-5.nc", "r")
+    entry = DBEntry(test_data_dir / "iter_md_magnetics_150100_5.nc", "r")
     ids = entry.get("magnetics", autoconvert=False)
 
     reader._ids = ids
@@ -19,7 +19,7 @@ def test_load_position_magnetics(test_data_dir):
     r1 = ids.b_field_pol_probe[0].position.r
     phi1 = ids.b_field_pol_probe[0].position.phi
     z1 = ids.b_field_pol_probe[0].position.z
-    name1 = f"{ids.b_field_pol_probe[0].name} / {ids.b_field_pol_probe[0].identifier}"
+    name1 = f"{ids.b_field_pol_probe[0].name}"
     point1 = (*pol_to_cart(r1, phi1), z1)
     output = vtkPolyData()
     reader._selected = [name1]

--- a/imas_paraview/tests/test_position.py
+++ b/imas_paraview/tests/test_position.py
@@ -7,12 +7,10 @@ from imas_paraview.plugins.position import PositionReader
 from imas_paraview.util import pol_to_cart
 
 
-def test_load_position_magnetics():
+def test_load_position_magnetics(test_data_dir):
     """Test if positions of magnetics barometry IDS are saved into vtkPolyData."""
     reader = PositionReader()
-    entry = DBEntry(
-        "/home/ITER/blokhus/public/imas_paraview_tests/iter_md-150100-5.nc", "r"
-    )
+    entry = DBEntry(test_data_dir / "iter_md-150100-5.nc", "r")
     ids = entry.get("magnetics", autoconvert=False)
 
     reader._ids = ids

--- a/imas_paraview/tests/test_position.py
+++ b/imas_paraview/tests/test_position.py
@@ -36,7 +36,6 @@ def test_load_position_magnetics():
     assert np.all(np.isclose(point1, output.GetPoint(0)))
 
 
-@pytest.mark.skip(reason="no IMAS-Core available")
 def test_load_position_barometry():
     """Test if positions of gauges of barometry IDS are saved into vtkPolyData."""
     ids = imas.IDSFactory().barometry()

--- a/imas_paraview/tests/test_profiles_1d.py
+++ b/imas_paraview/tests/test_profiles_1d.py
@@ -6,13 +6,11 @@ from vtkmodules.vtkCommonDataModel import vtkTable
 from imas_paraview.plugins.profiles_1d import Profiles1DReader
 
 
-def test_load_profiles_1d():
+def test_load_profiles_1d(test_data_dir):
     """Test if 1D profile structures are loaded in the VTK Table."""
     reader = Profiles1DReader()
 
-    with DBEntry(
-        "/home/ITER/blokhus/public/imas_paraview_tests/jintrac_53298-2.nc", "r"
-    ) as entry:
+    with DBEntry(test_data_dir / "jintrac_53298-2.nc", "r") as entry:
         ids = entry.get("core_profiles", autoconvert=False)
         reader._ids = ids
         reader.setup_ids()

--- a/imas_paraview/tests/test_profiles_1d.py
+++ b/imas_paraview/tests/test_profiles_1d.py
@@ -1,0 +1,46 @@
+import numpy as np
+from imas import DBEntry
+from vtk.util.numpy_support import vtk_to_numpy
+from vtkmodules.vtkCommonDataModel import vtkTable
+
+from imas_paraview.plugins.profiles_1d import Profiles1DReader
+
+
+def test_load_profiles_1d():
+    """Test if 1D profile structures are loaded in the VTK Table."""
+    reader = Profiles1DReader()
+
+    with DBEntry(
+        "/home/ITER/blokhus/public/imas_paraview_tests/jintrac_53298-2.nc", "r"
+    ) as entry:
+        ids = entry.get("core_profiles", autoconvert=False)
+        reader._ids = ids
+        reader.setup_ids()
+
+        profile1 = ids.profiles_1d[0].electrons.temperature
+        name1 = "Electrons Temperature"
+        profile2 = ids.profiles_1d[0].j_total
+        name2 = "J_total"
+
+        # 1 selection
+        output = vtkTable()
+        reader._selected = [name1]
+        reader._load_profiles(output)
+
+        check_table(output, [(name1, profile1)])
+
+        # 2 selections
+        output = vtkTable()
+        reader._selected = [name1, name2]
+        reader._load_profiles(output)
+
+        check_table(output, [(name1, profile1), (name2, profile2)])
+
+
+def check_table(vtk_table, expected_profiles):
+    """Assert that the data in the vtkTable matches the expected 1D profiles."""
+    assert vtk_table.GetNumberOfColumns() == len(expected_profiles) + 1
+
+    for name, profile in expected_profiles:
+        array = vtk_to_numpy(vtk_table.GetColumnByName(name))
+        assert np.array_equal(profile.ravel(), array)

--- a/imas_paraview/tests/test_profiles_1d.py
+++ b/imas_paraview/tests/test_profiles_1d.py
@@ -10,7 +10,7 @@ def test_load_profiles_1d(test_data_dir):
     """Test if 1D profile structures are loaded in the VTK Table."""
     reader = Profiles1DReader()
 
-    with DBEntry(test_data_dir / "jintrac_53298-2.nc", "r") as entry:
+    with DBEntry(test_data_dir / "iter_scenario_53298_seq1_DD4.nc", "r") as entry:
         ids = entry.get("core_profiles", autoconvert=False)
         reader._ids = ids
         reader.setup_ids()

--- a/imas_paraview/tests/test_profiles_2d.py
+++ b/imas_paraview/tests/test_profiles_2d.py
@@ -8,14 +8,12 @@ from vtkmodules.vtkCommonDataModel import vtkPartitionedDataSetCollection
 from imas_paraview.plugins.profiles_2d import Profiles2DReader
 
 
-def test_load_profiles():
+def test_load_profiles(test_data_dir):
     """Test if 2D profiles structures are loaded in the VTK
     PartitionedDatasetCollection."""
     reader = Profiles2DReader()
 
-    with DBEntry(
-        "/home/ITER/blokhus/public/imas_paraview_tests/iter_sce_110004-1.nc", "r"
-    ) as entry:
+    with DBEntry(test_data_dir / "iter_sce_110004-1.nc", "r") as entry:
         ids = entry.get("equilibrium", autoconvert=False)
         reader._ids = ids
         reader.setup_ids()

--- a/imas_paraview/tests/test_profiles_2d.py
+++ b/imas_paraview/tests/test_profiles_2d.py
@@ -13,16 +13,15 @@ def test_load_profiles(test_data_dir):
     PartitionedDatasetCollection."""
     reader = Profiles2DReader()
 
-    with DBEntry(test_data_dir / "iter_sce_110004-1.nc", "r") as entry:
+    with DBEntry(test_data_dir / "iter_scenario_53298_seq1_DD4.nc", "r") as entry:
         ids = entry.get("equilibrium", autoconvert=False)
         reader._ids = ids
         reader.setup_ids()
 
         profile1 = ids.time_slice[0].profiles_2d[0].psi
         name1 = "Psi"
-        profile2 = ids.time_slice[0].profiles_2d[0].j_tor
-        name2 = "J_tor"
-
+        profile2 = ids.time_slice[0].profiles_2d[0].b_field_phi
+        name2 = "B_field_phi"
         # 1 selection
         output = vtkPartitionedDataSetCollection()
         reader._selected = [name1]

--- a/imas_paraview/tests/test_profiles_2d.py
+++ b/imas_paraview/tests/test_profiles_2d.py
@@ -14,9 +14,9 @@ def test_load_profiles():
     reader = Profiles2DReader()
 
     with DBEntry(
-        "/home/ITER/blokhus/public/imas_paraview_tests/equilibrium.nc", "r"
+        "/home/ITER/blokhus/public/imas_paraview_tests/iter_sce_110004-1.nc", "r"
     ) as entry:
-        ids = entry.get("equilibrium", lazy=True, autoconvert=False)
+        ids = entry.get("equilibrium", autoconvert=False)
         reader._ids = ids
         reader.setup_ids()
 

--- a/imas_paraview/tests/test_profiles_2d.py
+++ b/imas_paraview/tests/test_profiles_2d.py
@@ -1,6 +1,5 @@
 import imas
 import numpy as np
-import pytest
 from imas import DBEntry
 from imas.backends.imas_core.db_entry_helpers import IDS_TIME_MODE_HOMOGENEOUS
 from vtk.util.numpy_support import vtk_to_numpy
@@ -9,15 +8,13 @@ from vtkmodules.vtkCommonDataModel import vtkPartitionedDataSetCollection
 from imas_paraview.plugins.profiles_2d import Profiles2DReader
 
 
-@pytest.mark.skip(reason="no IMAS-Core available")
 def test_load_profiles():
     """Test if 2D profiles structures are loaded in the VTK
     PartitionedDatasetCollection."""
     reader = Profiles2DReader()
 
     with DBEntry(
-        "imas:hdf5?path=/work/imas/shared/imasdb/ITER_SCENARIOS/3/110004/1",
-        "r",
+        "/home/ITER/blokhus/public/imas_paraview_tests/equilibrium.nc", "r"
     ) as entry:
         ids = entry.get("equilibrium", lazy=True, autoconvert=False)
         reader._ids = ids

--- a/imas_paraview/tests/test_wall_limiter.py
+++ b/imas_paraview/tests/test_wall_limiter.py
@@ -10,8 +10,10 @@ def test_load_limiters():
     """Test if limiters are loaded in the VTK Multiblock Dataset."""
     reader = WallLimiterReader()
 
-    with DBEntry("/home/ITER/blokhus/public/imas_paraview_tests/wall.nc", "r") as entry:
-        ids = entry.get("wall", lazy=True, autoconvert=False)
+    with DBEntry(
+        "/home/ITER/blokhus/public/imas_paraview_tests/iter_md-116000-5.nc", "r"
+    ) as entry:
+        ids = entry.get("wall", autoconvert=False)
         reader._ids = ids
         reader.setup_ids()
         description_name = ids.description_2d[0].type.name

--- a/imas_paraview/tests/test_wall_limiter.py
+++ b/imas_paraview/tests/test_wall_limiter.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 from imas import DBEntry
 from vtk.util.numpy_support import vtk_to_numpy
 from vtkmodules.vtkCommonDataModel import vtkMultiBlockDataSet
@@ -7,15 +6,11 @@ from vtkmodules.vtkCommonDataModel import vtkMultiBlockDataSet
 from imas_paraview.plugins.wall_limiter import WallLimiterReader
 
 
-@pytest.mark.skip(reason="no IMAS-Core available")
 def test_load_limiters():
     """Test if limiters are loaded in the VTK Multiblock Dataset."""
     reader = WallLimiterReader()
 
-    with DBEntry(
-        "imas:hdf5?path=/work/imas/shared/imasdb/ITER_MACHINE_DESCRIPTION/3/116000/5/",
-        "r",
-    ) as entry:
+    with DBEntry("/home/ITER/blokhus/public/imas_paraview_tests/wall.nc", "r") as entry:
         ids = entry.get("wall", lazy=True, autoconvert=False)
         reader._ids = ids
         reader.setup_ids()

--- a/imas_paraview/tests/test_wall_limiter.py
+++ b/imas_paraview/tests/test_wall_limiter.py
@@ -6,13 +6,11 @@ from vtkmodules.vtkCommonDataModel import vtkMultiBlockDataSet
 from imas_paraview.plugins.wall_limiter import WallLimiterReader
 
 
-def test_load_limiters():
+def test_load_limiters(test_data_dir):
     """Test if limiters are loaded in the VTK Multiblock Dataset."""
     reader = WallLimiterReader()
 
-    with DBEntry(
-        "/home/ITER/blokhus/public/imas_paraview_tests/iter_md-116000-5.nc", "r"
-    ) as entry:
+    with DBEntry(test_data_dir / "iter_md-116000-5.nc", "r") as entry:
         ids = entry.get("wall", autoconvert=False)
         reader._ids = ids
         reader.setup_ids()

--- a/imas_paraview/tests/test_wall_limiter.py
+++ b/imas_paraview/tests/test_wall_limiter.py
@@ -10,7 +10,7 @@ def test_load_limiters(test_data_dir):
     """Test if limiters are loaded in the VTK Multiblock Dataset."""
     reader = WallLimiterReader()
 
-    with DBEntry(test_data_dir / "iter_md-116000-5.nc", "r") as entry:
+    with DBEntry(test_data_dir / "iter_md_wall_116000_5.nc", "r") as entry:
         ids = entry.get("wall", autoconvert=False)
         reader._ids = ids
         reader.setup_ids()


### PR DESCRIPTION
This PR introduces updated and expanded test coverage using real IDS data stored in NetCDF format. It includes:

- Test for the 1D profile reader using JINTRAC dataset.
- New tests for loading GGDs using SOLPS and JOREK datasets.
- Existing test datasets are converted to NetCDF and stored in a local directory on SDCC: `/home/ITER/blokhus/public/imas_paraview_tests`

All tests been run and pass when executed on SDCC.

Next Steps:

- [x] Request approval for publication of test datasets.
- [x] The IDSs are fetched from local SDCC directories, these should be fetched elsewhere, and ideally cached in the CI.