### PR TITLE
Disable mdsplus/hdf5 integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,7 @@ jobs:
     - name: Run tests
       run: |
         export PATH="$PWD/paraview/bin:$PATH"
-        pvpython --venv venv -m pytest --cov=imas_paraview --cov-report=term-missing --cov-report=html
+        pvpython --venv venv -m pytest --skip-mdsplus --skip-hdf5 --cov=imas_paraview --cov-report=term-missing --cov-report=html
 
     - name: Upload coverage report
       uses: actions/upload-artifact@v4

--- a/imas_paraview/tests/conftest.py
+++ b/imas_paraview/tests/conftest.py
@@ -35,6 +35,21 @@ def set_environment():
     print(f"PYTHONPATH={os.environ['PYTHONPATH']}")
 
 
+def pytest_addoption(parser):
+    parser.addoption(
+        "--skip-hdf5",
+        action="store_true",
+        default=False,
+        help="Skip integration tests for HDF5 datasets",
+    )
+    parser.addoption(
+        "--skip-mdsplus",
+        action="store_true",
+        default=False,
+        help="Skip integration tests for MDSplus datasets",
+    )
+
+
 def pytest_sessionstart(session):
     """Set up the environment variables and generate test data to
     perform the integration tests on."""
@@ -56,18 +71,19 @@ def pytest_sessionstart(session):
         )
         return
 
-    # TODO: Enable hdf5/mdsplus integration tests using open-source imas-core
-    # # Write test file as MDSPlus
-    # with imas.DBEntry(
-    #     "imas:mdsplus?path=mdsplus_testdb", "w", dd_version=DD_VERSION
-    # ) as dbentry:
-    #     dbentry.put(ids)
-    #
-    # # Write test file as HDF5
-    # with imas.DBEntry(
-    #     "imas:hdf5?path=hdf5_testdb", "w", dd_version=DD_VERSION
-    # ) as dbentry:
-    #     dbentry.put(ids)
+    # Write integration test file as MDSPlus
+    if not session.config.getoption("--skip-mdsplus"):
+        with imas.DBEntry(
+            "imas:mdsplus?path=mdsplus_testdb", "w", dd_version=DD_VERSION
+        ) as dbentry:
+            dbentry.put(ids)
+
+    # Write integration test file as HDF5
+    if not session.config.getoption("--skip-hdf5"):
+        with imas.DBEntry(
+            "imas:hdf5?path=hdf5_testdb", "w", dd_version=DD_VERSION
+        ) as dbentry:
+            dbentry.put(ids)
 
     print("Test environment setup complete.")
 

--- a/imas_paraview/tests/conftest.py
+++ b/imas_paraview/tests/conftest.py
@@ -56,17 +56,18 @@ def pytest_sessionstart(session):
         )
         return
 
-    # Write test file as MDSPlus
-    with imas.DBEntry(
-        "imas:mdsplus?path=mdsplus_testdb", "w", dd_version=DD_VERSION
-    ) as dbentry:
-        dbentry.put(ids)
-
-    # Write test file as HDF5
-    with imas.DBEntry(
-        "imas:hdf5?path=hdf5_testdb", "w", dd_version=DD_VERSION
-    ) as dbentry:
-        dbentry.put(ids)
+    # TODO: Enable hdf5/mdsplus integration tests using open-source imas-core
+    # # Write test file as MDSPlus
+    # with imas.DBEntry(
+    #     "imas:mdsplus?path=mdsplus_testdb", "w", dd_version=DD_VERSION
+    # ) as dbentry:
+    #     dbentry.put(ids)
+    #
+    # # Write test file as HDF5
+    # with imas.DBEntry(
+    #     "imas:hdf5?path=hdf5_testdb", "w", dd_version=DD_VERSION
+    # ) as dbentry:
+    #     dbentry.put(ids)
 
     print("Test environment setup complete.")
 

--- a/imas_paraview/tests/integration_tests/test_integration.py
+++ b/imas_paraview/tests/integration_tests/test_integration.py
@@ -87,12 +87,12 @@ def test_xvfb_fail():
 @pytest.mark.parametrize(
     "test_script", [pytest.param(script, id=script.name) for script in TEST_SCRIPTS]
 )
-def test_integration_scripts(test_script):
+def test_integration_scripts(test_script, request):
     """Parameterized test function for running integration tests."""
-    if "hdf5" in str(test_script) and not Path("hdf5_testdb").exists():
-        pytest.skip("HDF5 testdb does not exist")
-    if "mdsplus" in str(test_script) and not Path("mdsplus_testdb").exists():
-        pytest.skip("MDSplus testdb does not exist")
+    if "hdf5" in str(test_script) and request.config.getoption("--skip-hdf5"):
+        pytest.skip("Skipping HDF5 integration tests")
+    if "mdsplus" in str(test_script) and request.config.getoption("--skip-mdsplus"):
+        pytest.skip("Skipping MDSplus integration tests")
     if "profiles_1d_mapper" in str(test_script):
         pytest.skip("Requires ITER data, not available on GH Actions")
     test_passed = run_test(test_script)


### PR DESCRIPTION
There are some issues with the MDSPlus and HDF5 integration tests using the open-source version of imas-core.  Let's skip them for now.