### PR TITLE
Add additional ruff lint rules

### DIFF
--- a/imas_paraview/__init__.py
+++ b/imas_paraview/__init__.py
@@ -48,6 +48,8 @@ imas_version = imas.__version__
 required_imas_python_version = "2.0.0"
 if version.parse(imas_version) < version.parse(required_imas_python_version):
     logger.warning(
-        f"IMAS-Python version {imas_version} is lower than the recommended version "
-        f"{required_imas_python_version}. Some features might not work as expected."
+        "IMAS-Python version %s is lower than the recommended version %s. "
+        "Some features might not work as expected.",
+        imas_version,
+        required_imas_python_version,
     )

--- a/imas_paraview/cli.py
+++ b/imas_paraview/cli.py
@@ -380,10 +380,10 @@ def parse_time(ids_times, time):
         for input_time in time.split(","):
             try:
                 float(input_time)
-            except ValueError:
+            except ValueError as err:
                 raise click.UsageError(
                     "All time steps in given list must be valid floats."
-                )
+                ) from err
         time_list = [float(x.strip()) for x in time.split(",")]
         index_list = find_closest_indices(time_list, ids_times)
         indices_dict = OrderedDict.fromkeys(index_list)
@@ -405,10 +405,10 @@ def parse_time(ids_times, time):
         try:
             start = float(start_str)
             end = float(end_str)
-        except ValueError:
+        except ValueError as err:
             raise click.UsageError(
                 "The minimum and maximum range values must be valid floats."
-            )
+            ) from err
         if end < start:
             raise click.UsageError(
                 "The final time index in range must be greater than the first."
@@ -421,13 +421,13 @@ def parse_time(ids_times, time):
         try:
             time_list = [float(time)]
             index_list = find_closest_indices(time_list, ids_times)
-        except ValueError:
+        except ValueError as err:
             raise click.UsageError(
                 "Could not determine which time steps should be converted.\n"
                 "Provide either a single float ('-t 5.0'), "
                 "a list of floats ('-t 2.1,3.5,4') or "
                 "a range of floats ('-t 2.2:4.4')"
-            )
+            ) from err
     click.echo(f"Converting the following time steps: {ids_times[index_list]}")
     return index_list
 

--- a/imas_paraview/convert.py
+++ b/imas_paraview/convert.py
@@ -50,17 +50,17 @@ class Converter:
             index_list: A list of time indices to convert. By default only the first
                 time step is converted.
         """
-        logger.info(f"Creating a output directory at {output_path}")
+        logger.info("Creating a output directory at %s", output_path)
         output_path.mkdir(parents=True, exist_ok=True)
         output_path = output_path / self.ids.metadata.name
         if any(index >= len(self.ids.time) for index in index_list):
             raise RuntimeError("A provided index is out of bounds.")
 
         for index in index_list:
-            logger.info(f"Converting time step {self.ids.time[index]}...")
+            logger.info("Converting time step %f...", self.ids.time[index])
             vtk_object = self.ggd_to_vtk(time_idx=index)
             if vtk_object is None:
-                logger.warning(f"Could not convert GGD at time index {index} to VTK.")
+                logger.warning("Could not convert GGD at time index %d to VTK.", index)
                 continue
             self._write_vtk_to_xml(vtk_object, Path(f"{output_path}_{index}"))
 
@@ -136,7 +136,7 @@ class Converter:
         Retrieve the GGD grid from a reference IDS path and replace the current grid.
         """
         path = self.grid_ggd.path
-        logger.info(f"Fetching the GGD grid from the reference: '{path}'")
+        logger.info("Fetching the GGD grid from the reference: %r", path)
         path = path.strip("#")
         ids_name, path = path.split("/", 1)
         if ids_name not in self.dbentry.factory.ids_names():
@@ -188,15 +188,18 @@ class Converter:
             else:
                 time_idx = indices[0]
             logger.info(
-                f"Converting timestep: t = {self.ids.time[time_idx]} at index = "
-                f"{time_idx}"
+                "Converting timestep: t = %f at index = %d",
+                self.ids.time[time_idx],
+                time_idx,
             )
             return time_idx
         else:
             time_idx = len(self.ids.time) // 2
             logger.info(
-                "No time or time index provided, so converting the middle time "
-                f"step: t = {self.ids.time[time_idx]} at index {time_idx}."
+                "No time or time index provided, so converting the middle time step: "
+                "t = %f at index %d.",
+                self.ids.time[time_idx],
+                time_idx,
             )
             return time_idx
 
@@ -351,9 +354,9 @@ class Converter:
             logger.error("Cannot write None object to XML.")
             return
 
-        logger.info(f"Writing VTK file to {output_path}...")
+        logger.info("Writing VTK file to %r...", output_path)
         writer = vtkXMLPartitionedDataSetCollectionWriter()
         writer.SetInputData(vtk_object)
         writer.SetFileName(output_path.with_suffix(".vtpc"))
         writer.Write()
-        logger.info(f"Successfully wrote VTK object to {output_path}")
+        logger.info("Successfully wrote VTK object to %r", output_path)

--- a/imas_paraview/convert.py
+++ b/imas_paraview/convert.py
@@ -2,6 +2,7 @@ import logging
 from dataclasses import dataclass
 from functools import lru_cache
 from pathlib import Path
+from typing import Optional
 
 from vtk import vtkXMLPartitionedDataSetCollectionWriter
 from vtkmodules.vtkCommonCore import vtkPoints
@@ -41,7 +42,7 @@ class Converter:
         self.reference_grid_path = None
         self.get_grids = lru_cache(maxsize=32)(self.get_grids)
 
-    def write_to_xml(self, output_path: Path, index_list=[0]):
+    def write_to_xml(self, output_path: Path, index_list=None):
         """Convert an IDS to VTK format and write it to disk using the XML output
         writer.
 
@@ -50,6 +51,8 @@ class Converter:
             index_list: A list of time indices to convert. By default only the first
                 time step is converted.
         """
+        if index_list is None:
+            index_list = [0]
         logger.info("Creating a output directory at %s", output_path)
         output_path.mkdir(parents=True, exist_ok=True)
         output_path = output_path / self.ids.metadata.name
@@ -70,7 +73,7 @@ class Converter:
         time_idx=None,
         scalar_paths=None,
         vector_paths=None,
-        plane_config: InterpSettings = InterpSettings(),
+        plane_config: Optional[InterpSettings] = None,
         outInfo=None,
         progress=None,
         parent_idx=0,
@@ -91,6 +94,8 @@ class Converter:
         Returns:
             vtkPartitionedDataSetCollection containing the converted GGD data.
         """
+        if plane_config is None:
+            plane_config = InterpSettings()
         self.points = vtkPoints()
         self.assembly = vtkDataAssembly()
         self.time_idx = self._resolve_time_idx(time_idx, time)
@@ -126,7 +131,7 @@ class Converter:
         self.ps_reader = read_ps.PlasmaStateReader(self.ids)
         self.ps_reader.load_arrays_from_path(self.time_idx, scalar_paths, vector_paths)
 
-        self.is_jorek = True if plane_config.n_plane != 0 else False
+        self.is_jorek = plane_config.n_plane != 0
         self._fill_grid_and_plasma_state()
 
         return self.output
@@ -136,7 +141,7 @@ class Converter:
         Retrieve the GGD grid from a reference IDS path and replace the current grid.
         """
         path = self.grid_ggd.path
-        logger.info("Fetching the GGD grid from the reference: %r", path)
+        logger.info("Fetching the GGD grid from the reference: '%s'", path)
         path = path.strip("#")
         ids_name, path = path.split("/", 1)
         if ids_name not in self.dbentry.factory.ids_names():
@@ -155,8 +160,8 @@ class Converter:
         )
         try:
             self.grid_ggd = ids[path]
-        except KeyError:
-            raise ValueError(f"{path} does not exist in {ids}.")
+        except KeyError as err:
+            raise ValueError(f"{path} does not exist in {ids}.") from err
 
     def _resolve_time_idx(self, time_idx, time):
         """Resolves the appropriate time index based on the given time index or time
@@ -354,9 +359,9 @@ class Converter:
             logger.error("Cannot write None object to XML.")
             return
 
-        logger.info("Writing VTK file to %r...", output_path)
+        logger.info("Writing VTK file to '%s'...", output_path)
         writer = vtkXMLPartitionedDataSetCollectionWriter()
         writer.SetInputData(vtk_object)
         writer.SetFileName(output_path.with_suffix(".vtpc"))
         writer.Write()
-        logger.info("Successfully wrote VTK object to %r", output_path)
+        logger.info("Successfully wrote VTK object to '%s'", output_path)

--- a/imas_paraview/ids_util.py
+++ b/imas_paraview/ids_util.py
@@ -117,9 +117,9 @@ def create_name_recursive(node):
     name_current_node = node.metadata.name
     name = ""
     if (
-        "ggd" != name_current_node
-        and "profiles_1d" != name_current_node
-        and "profiles_2d" != name_current_node
+        name_current_node != "ggd"
+        and name_current_node != "profiles_1d"
+        and name_current_node != "profiles_2d"
         and "time_slice" not in name_current_node
     ):
         name_appendix = ""

--- a/imas_paraview/io/read_geom.py
+++ b/imas_paraview/io/read_geom.py
@@ -63,7 +63,7 @@ def fill_vtk_points(
         progress: Progress indicator for Paraview.
     """
     num_objects0d = len(grid_ggd.space[space_idx].objects_per_dimension[0].object)
-    logger.info(f"Reading {num_objects0d} points from grid_ggd/space[{space_idx}]")
+    logger.info("Reading %d points from grid_ggd/space[%d]", num_objects0d, space_idx)
 
     s = 1  # scale objects from mm to m
     if len(grid_ggd.space[space_idx].objects_per_dimension[0].object[0].geometry) == 0:
@@ -147,10 +147,12 @@ def _fill_vtk_cell_array_from_gs(
     num_gs_el = len(grid_subset.element)
 
     if hasattr(grid_subset, "identifier"):
-        logger.info(f"Reading {num_gs_el} elements from {grid_subset.identifier.name}")
+        logger.info(
+            "Reading %d elements from %s", num_gs_el, grid_subset.identifier.name
+        )
     else:
         logger.info(
-            f"Reading {num_gs_el} elements from grid_ggd/grid_subset[{subset_idx}]"
+            "Reading %d elements from grid_ggd/grid_subset[%d]", num_gs_el, subset_idx
         )
 
     ugrid.AllocateEstimate(num_gs_el, 10)

--- a/imas_paraview/io/read_geom.py
+++ b/imas_paraview/io/read_geom.py
@@ -121,7 +121,7 @@ def _fill_vtk_cell_array_from_gs2(
         obj_nodes = obj.nodes
         obj_dimension = 2
 
-        pt_ids = [(val - 1 for val in obj_nodes)]
+        pt_ids = [val - 1 for val in obj_nodes]
         npts = len(pt_ids)
         cell_type = _get_vtk_cell_type(obj_dimension, npts)
         ugrid.InsertNextCell(cell_type, npts, pt_ids)
@@ -175,7 +175,7 @@ def _fill_vtk_cell_array_from_gs(
             )
 
             pt_ids = [
-                (val - 1 for val in obj_nodes)
+                val - 1 for val in obj_nodes
             ]  # offset by -1 as fortran indexing used in IMAS( 1,...n)
             npts = len(pt_ids)
             cell_type = _get_vtk_cell_type(obj_dimension, npts)
@@ -196,7 +196,7 @@ def _fill_vtk_cell_array_from_gs(
                         .object[object_2d_idx]
                     )
                     object_2d_pt_ids = [
-                        (val - 1 for val in object_2d.nodes)
+                        val - 1 for val in object_2d.nodes
                     ]  # offset by -1
                     num_face_pts = len(object_2d_pt_ids)
 

--- a/imas_paraview/io/read_geom.py
+++ b/imas_paraview/io/read_geom.py
@@ -174,9 +174,8 @@ def _fill_vtk_cell_array_from_gs(
                 .boundary
             )
 
-            pt_ids = [
-                val - 1 for val in obj_nodes
-            ]  # offset by -1 as fortran indexing used in IMAS( 1,...n)
+            # offset by -1 as fortran indexing used in IMAS( 1,...n)
+            pt_ids = [val - 1 for val in obj_nodes]
             npts = len(pt_ids)
             cell_type = _get_vtk_cell_type(obj_dimension, npts)
 
@@ -195,9 +194,8 @@ def _fill_vtk_cell_array_from_gs(
                         .objects_per_dimension[2]
                         .object[object_2d_idx]
                     )
-                    object_2d_pt_ids = [
-                        val - 1 for val in object_2d.nodes
-                    ]  # offset by -1
+                    # offset by -1
+                    object_2d_pt_ids = [val - 1 for val in object_2d.nodes]
                     num_face_pts = len(object_2d_pt_ids)
 
                     # the format for 3d cell point ids is

--- a/imas_paraview/io/read_geom.py
+++ b/imas_paraview/io/read_geom.py
@@ -120,12 +120,8 @@ def _fill_vtk_cell_array_from_gs2(
         obj = grid[2].object[j]
         obj_nodes = obj.nodes
         obj_dimension = 2
-        # try:
-        #     obj_boundary = obj.boundary
-        # except:
-        #     obj_boundary = []
 
-        pt_ids = list(map(lambda val: val - 1, obj_nodes))
+        pt_ids = [(val - 1 for val in obj_nodes)]
         npts = len(pt_ids)
         cell_type = _get_vtk_cell_type(obj_dimension, npts)
         ugrid.InsertNextCell(cell_type, npts, pt_ids)
@@ -178,9 +174,9 @@ def _fill_vtk_cell_array_from_gs(
                 .boundary
             )
 
-            pt_ids = list(
-                map(lambda val: val - 1, obj_nodes)
-            )  # offset by -1 as fortran indexing used in IMAS( 1,...n)
+            pt_ids = [
+                (val - 1 for val in obj_nodes)
+            ]  # offset by -1 as fortran indexing used in IMAS( 1,...n)
             npts = len(pt_ids)
             cell_type = _get_vtk_cell_type(obj_dimension, npts)
 
@@ -199,9 +195,9 @@ def _fill_vtk_cell_array_from_gs(
                         .objects_per_dimension[2]
                         .object[object_2d_idx]
                     )
-                    object_2d_pt_ids = list(
-                        map(lambda val: val - 1, object_2d.nodes)
-                    )  # offset by -1
+                    object_2d_pt_ids = [
+                        (val - 1 for val in object_2d.nodes)
+                    ]  # offset by -1
                     num_face_pts = len(object_2d_pt_ids)
 
                     # the format for 3d cell point ids is

--- a/imas_paraview/io/read_jorek.py
+++ b/imas_paraview/io/read_jorek.py
@@ -164,7 +164,7 @@ def convert_grid_subset_to_unstructured_grid(
     else:
         alpha = (phi[1] - phi[0]) / (n_plane - 1)
         w = np.cos(np.deg2rad(alpha))
-        w1 = np.ones((np.shape(xyz)[0]))
+        w1 = np.ones(np.shape(xyz)[0])
         ien = None
         # Connectivity list of one bezier cell:
         index = np.array(

--- a/imas_paraview/io/read_jorek.py
+++ b/imas_paraview/io/read_jorek.py
@@ -45,7 +45,9 @@ def read_plasma_state(grid_ggd, ps_reader, plane_config, ugrid):
         elif hasattr(attribute_array[0], "phi_coefficients"):
             scalar_data = attribute_array[0].phi_coefficients
         else:
-            logger.warning(f"Could not load the coefficients for {name}, it is ignored")
+            logger.warning(
+                "Could not load the coefficients for %s, it is ignored", name
+            )
             continue
         nam.append(name)
         if np.size(val_tor1) == 0:

--- a/imas_paraview/io/read_jorek.py
+++ b/imas_paraview/io/read_jorek.py
@@ -32,7 +32,7 @@ def read_plasma_state(grid_ggd, ps_reader, plane_config, ugrid):
 
     phi = [plane_config.phi_start, plane_config.phi_end]
     val_tor1 = np.array([])
-    nam = list()
+    nam = []
 
     N_vertex = len(grid_ggd.space[0].objects_per_dimension[0].object)
     array_list = ps_reader.scalar_array_list + ps_reader.vector_array_list
@@ -348,8 +348,8 @@ def interp_scalars(values, vertex, size, n_sub):
     returns:
         values: interpolated values, values[var, harmonic, element, is, it]
     """
-    # Multiply values[var,order,harm,vertex,element] with
-    # size[order, vertex, element] and bf[order, vertex, s, t]
+    # Multiply values[var,order,harm,vertex,element] with size[order, vertex, element]
+    # and bf[order, vertex, s, t]
     return np.einsum(
         "lihjk,ijk,ijmn->lhkmn", values[:, :, :, vertex - 1], size, bf(n_sub)
     )

--- a/imas_paraview/io/read_ps.py
+++ b/imas_paraview/io/read_ps.py
@@ -283,9 +283,7 @@ class PlasmaStateReader:
                         self._add_scalar_array_to_vtk_field_data(
                             aos_scalar_node[i].values, name, ugrid
                         )
-                except IndexError:
-                    logger.warning("no index %d for subset %d...", i, subset_idx)
-                except AttributeError:
+                except (IndexError, AttributeError):
                     logger.warning("no index %d for subset %d...", i, subset_idx)
         else:
             if hasattr(aos_scalar_node[subset_idx], "values") and len(

--- a/imas_paraview/io/read_ps.py
+++ b/imas_paraview/io/read_ps.py
@@ -321,9 +321,12 @@ class PlasmaStateReader:
         # Search for filled 1D vector components
         for component in aos_vector_node[subset_idx]:
             metadata = component.metadata
-            if metadata.data_type == IDSDataType.FLT and metadata.ndim == 1:
-                if len(component):
-                    components[metadata.name] = component.value
+            if (
+                metadata.data_type == IDSDataType.FLT
+                and metadata.ndim == 1
+                and len(component)
+            ):
+                components[metadata.name] = component.value
 
         vtk_arr = vtkDoubleArray()
         vtk_arr.SetName(name)

--- a/imas_paraview/io/read_ps.py
+++ b/imas_paraview/io/read_ps.py
@@ -316,7 +316,7 @@ class PlasmaStateReader:
         num_cells = ugrid.GetNumberOfCells()
 
         # Only add the components that have data:
-        components = dict()  # name and values
+        components = {}  # name and values
 
         # Search for filled 1D vector components
         for component in aos_vector_node[subset_idx]:

--- a/imas_paraview/io/read_ps.py
+++ b/imas_paraview/io/read_ps.py
@@ -96,8 +96,9 @@ class PlasmaStateReader:
             vector_array_paths=vector_array_paths,
         )
         logger.debug(
-            f"Found {len(self.scalar_array_list)} scalar arrays and "
-            f"{len(self.vector_array_list)} vector arrays in the IDS."
+            "Found %d scalar arrays and %d vector arrays in the IDS.",
+            len(self.scalar_array_list),
+            len(self.vector_array_list),
         )
 
     def read_plasma_state(self, subset_idx: int, ugrid: vtkUnstructuredGrid) -> None:
@@ -228,7 +229,7 @@ class PlasmaStateReader:
             ugrid: an instance of vtkUnstructuredGrid
         """
 
-        logger.debug(f"           {name}...")
+        logger.debug("Adding scalar array: %s...", name)
         point_data: vtkPointData = ugrid.GetPointData()
         num_points = ugrid.GetNumberOfPoints()
         cell_data: vtkCellData = ugrid.GetCellData()
@@ -268,7 +269,7 @@ class PlasmaStateReader:
             name: this becomes the array name in VTK
             ugrid: an unstructured grid instance
         """
-        logger.debug(f"           {name}...")
+        logger.debug("Adding AoS scalar array: %s...", name)
         if subset_idx >= len(aos_scalar_node):
             return
 
@@ -283,13 +284,9 @@ class PlasmaStateReader:
                             aos_scalar_node[i].values, name, ugrid
                         )
                 except IndexError:
-                    logger.warning(
-                        f"           no index {i} for subset {subset_idx}..."
-                    )
+                    logger.warning("no index %d for subset %d...", i, subset_idx)
                 except AttributeError:
-                    logger.warning(
-                        f"           no index {i} for subset {subset_idx}..."
-                    )
+                    logger.warning("no index %d for subset %d...", i, subset_idx)
         else:
             if hasattr(aos_scalar_node[subset_idx], "values") and len(
                 aos_scalar_node[subset_idx].values
@@ -309,7 +306,7 @@ class PlasmaStateReader:
             name: this becomes the array name in VTK
             ugrid: an unstructured grid instance
         """
-        logger.debug(f"           {name}...")
+        logger.debug("Adding AoS vector array: %s...", name)
         if subset_idx >= len(aos_vector_node):
             return
 

--- a/imas_paraview/plugins/base_class.py
+++ b/imas_paraview/plugins/base_class.py
@@ -65,7 +65,7 @@ class GGDVTKPluginBase(VTKPythonAlgorithmBase, ABC):
                 callable(value)
                 and not name.startswith("__")
                 and not getattr(value, "__isabstractmethod__", False)
-                and not name == "request_information"
+                and name != "request_information"
             ):
                 if name in bezier_methods:
                     if use_bezier:
@@ -165,7 +165,7 @@ class GGDVTKPluginBase(VTKPythonAlgorithmBase, ABC):
                 # Try to open the DBEntry
                 try:
                     self._dbentry = imas.DBEntry(self._uri, "r")
-                    logger.info("Successfully opened URI %r.", self._uri)
+                    logger.info("Successfully opened URI '%s'.", self._uri)
                 except Exception as exc:
                     self._uri_error = str(exc)
             self._update_ids_list()
@@ -320,10 +320,13 @@ class GGDVTKPluginBase(VTKPythonAlgorithmBase, ABC):
             while node:
                 parent = imas.util.get_parent(node)
                 # if parent and node have the same metadata, it means node = parent[idx]
-                if parent and parent.metadata is node.metadata:
-                    if not node.metadata.coordinate1.is_time_coordinate:
-                        for i in range(len(parent)):
-                            arr.InsertNextValue(f"{node.metadata.name}[{i}]")
+                if (
+                    parent
+                    and parent.metadata is node.metadata
+                    and not node.metadata.coordinate1.is_time_coordinate
+                ):
+                    for i in range(len(parent)):
+                        arr.InsertNextValue(f"{node.metadata.name}[{i}]")
                 node = parent
         if arr.GetNumberOfValues() == 0:
             arr.InsertNextValue("N/A")

--- a/imas_paraview/plugins/base_class.py
+++ b/imas_paraview/plugins/base_class.py
@@ -165,7 +165,7 @@ class GGDVTKPluginBase(VTKPythonAlgorithmBase, ABC):
                 # Try to open the DBEntry
                 try:
                     self._dbentry = imas.DBEntry(self._uri, "r")
-                    logger.info(f'Successfully opened URI "{self._uri}".')
+                    logger.info("Successfully opened URI %r.", self._uri)
                 except Exception as exc:
                     self._uri_error = str(exc)
             self._update_ids_list()
@@ -424,7 +424,7 @@ class GGDVTKPluginBase(VTKPythonAlgorithmBase, ABC):
         else:
             status = "disabled"
             self.lazy = False
-        logger.info(f"Lazy Loading is {status}.")
+        logger.info("Lazy Loading is %s.", status)
         self.Modified()
 
     # Properties for handling time steps
@@ -618,12 +618,14 @@ class GGDVTKPluginBase(VTKPythonAlgorithmBase, ABC):
 
         # Check if it exists in list of time steps
         if time_step in self._time_steps:
-            logger.debug(f"Selected time step in Paraview: {time_step}")
+            logger.debug("Selected time step in Paraview: %f", time_step)
             return time_step
         elif self._time_steps:
             logger.info(
-                f"Selected time step {time_step} was not found in the IDS. "
-                f"The first time step ({self._time_steps[0]}) is loaded instead."
+                "Selected time step %f was not found in the IDS. "
+                "The first time step (%f) is loaded instead.",
+                time_step,
+                self._time_steps[0],
             )
             return self._time_steps[0]
         else:

--- a/imas_paraview/plugins/beam.py
+++ b/imas_paraview/plugins/beam.py
@@ -69,7 +69,8 @@ class BeamReader(GGDVTKPluginBase, is_time_dependent=True):
             if beam_name == "":
                 beam_name = f"beam {i}"
                 logger.warning(
-                    f"Found a channel without a name, it will be loaded as {beam_name}."
+                    "Found a channel without a name, it will be loaded as %s.",
+                    beam_name,
                 )
             self.selectable_map[str(beam_name)] = beam
         self._selectable = list(self.selectable_map)
@@ -83,7 +84,7 @@ class BeamReader(GGDVTKPluginBase, is_time_dependent=True):
         """
         for i, beam_name in enumerate(self._selected):
             beam = self.selectable_map[beam_name]
-            logger.info(f"Selected {beam_name}")
+            logger.info("Selected %s", beam_name)
             vtk_poly = self._create_vtk_beam(beam, time_idx)
             output.SetBlock(i, vtk_poly)
 

--- a/imas_paraview/plugins/line_of_sight.py
+++ b/imas_paraview/plugins/line_of_sight.py
@@ -80,8 +80,8 @@ class LineOfSightReader(GGDVTKPluginBase):
             if channel_name == "":
                 channel_name = f"channel {i}"
                 logger.warning(
-                    "Found a channel without a name, "
-                    f"it will be loaded as {channel_name}."
+                    "Found a channel without a name, it will be loaded as %s.",
+                    channel_name,
                 )
 
             # For ece, if the channel does not have a line of sight, or it is empty,
@@ -104,7 +104,7 @@ class LineOfSightReader(GGDVTKPluginBase):
         """
         for i, channel_name in enumerate(self._selected):
             channel = self.selectable_map[channel_name]
-            logger.info(f"Selected {channel_name}")
+            logger.info("Selected %s", channel_name)
             vtk_poly = self._create_vtk_los(channel)
             output.SetBlock(i, vtk_poly)
 

--- a/imas_paraview/plugins/position.py
+++ b/imas_paraview/plugins/position.py
@@ -72,7 +72,7 @@ class PositionReader(GGDVTKPluginBase):
                 if name == "":
                     name = f"device {i}"
                     logger.warning(
-                        f"Found a device without a name, it will be loaded as {name}."
+                        "Found a device without a name, it will be loaded as %s.", name
                     )
 
                 if hasattr(structure, "identifier"):
@@ -94,7 +94,7 @@ class PositionReader(GGDVTKPluginBase):
         for name in self._selected:
             pos_struct = self.selectable_map[name]
             pos = pos_struct.position
-            logger.info(f"Selected {name}")
+            logger.info("Selected %s", name)
 
             if isinstance(pos, IDSStructArray):
                 for pos_struct in pos:

--- a/imas_paraview/plugins/position.py
+++ b/imas_paraview/plugins/position.py
@@ -77,7 +77,7 @@ class PositionReader(GGDVTKPluginBase):
 
                 if hasattr(structure, "identifier"):
                     identifier = structure.identifier
-                    if not identifier == "":
+                    if identifier != "":
                         name = f"{name} / {identifier}"
 
                 self.selectable_map[str(name)] = structure

--- a/imas_paraview/plugins/profiles_1d.py
+++ b/imas_paraview/plugins/profiles_1d.py
@@ -174,7 +174,7 @@ class Profiles1DReader(GGDVTKPluginBase, is_time_dependent=True):
         Args:
             node: the node to search through.
         """
-        if isinstance(node, IDSStructure) or isinstance(node, IDSStructArray):
+        if isinstance(node, (IDSStructure, IDSStructArray)):
             for subnode in node:
                 self._recursive_find_profiles(subnode)
         else:

--- a/imas_paraview/plugins/profiles_1d.py
+++ b/imas_paraview/plugins/profiles_1d.py
@@ -59,7 +59,7 @@ class Profiles1DReader(GGDVTKPluginBase, is_time_dependent=True):
             profile = self.selectable_map[profile_name]
 
             if len(profile) == 0:
-                logger.warning(f"The selected profile {profile_name} is empty.")
+                logger.warning("The selected profile %s is empty.", profile_name)
                 continue
 
             path = profile.metadata.coordinate1.references[0]
@@ -70,7 +70,7 @@ class Profiles1DReader(GGDVTKPluginBase, is_time_dependent=True):
                 )
                 continue
 
-            logger.info(f"Selected {profile_name}.")
+            logger.info("Selected %s.", profile_name)
             y_values = self._create_vtk_double_array(profile, profile_name)
             output.AddColumn(y_values)
 

--- a/imas_paraview/plugins/profiles_2d.py
+++ b/imas_paraview/plugins/profiles_2d.py
@@ -73,7 +73,7 @@ class Profiles2DReader(GGDVTKPluginBase, is_time_dependent=True):
 
         if self._ids.metadata.name == "equilibrium":
             if not time_idx < len(self._ids.time_slice):
-                logger.error(f"There is no profiles_2d at time step {time_idx}")
+                logger.error("There is no profiles_2d at time step %d", time_idx)
                 return
             for profile in self._ids.time_slice[time_idx].profiles_2d:
                 self._search_valid_profile(profile)
@@ -82,7 +82,7 @@ class Profiles2DReader(GGDVTKPluginBase, is_time_dependent=True):
                     break
         else:
             if not time_idx < len(self._ids.profiles_2d):
-                logger.error(f"There is no profiles_2d at time step {time_idx}")
+                logger.error("There is no profiles_2d at time step %d", time_idx)
                 return
             profile = self._ids.profiles_2d[time_idx]
             self._search_valid_profile(profile)
@@ -122,8 +122,9 @@ class Profiles2DReader(GGDVTKPluginBase, is_time_dependent=True):
             grid_type = profile.grid_type.index
             if grid_type != 1:
                 logger.debug(
-                    f"Found a grid type with identifier index of {grid_type}. "
-                    "Only rectangular profiles (index = 1) are supported."
+                    "Found a grid type with identifier index of %d. "
+                    "Only rectangular profiles (index = 1) are supported.",
+                    grid_type,
                 )
                 return
             self.r = np.tile(profile.grid.dim1, (len(profile.grid.dim2), 1))
@@ -203,7 +204,7 @@ class Profiles2DReader(GGDVTKPluginBase, is_time_dependent=True):
 
         for i, profile_name in enumerate(self._selected):
             profile = self.selectable_map[profile_name]
-            logger.info(f"Selected {profile_name}")
+            logger.info("Selected %s", profile_name)
 
             vtk_scalars = self._create_vtkscalars(profile, profile_name)
             vtk_ugrid = self._create_ugrid(vtk_points, vtk_scalars)

--- a/imas_paraview/plugins/profiles_2d.py
+++ b/imas_paraview/plugins/profiles_2d.py
@@ -181,7 +181,7 @@ class Profiles2DReader(GGDVTKPluginBase, is_time_dependent=True):
 
         if node.metadata.name in ("grid", "r", "z"):
             return
-        elif isinstance(node, IDSStructure) or isinstance(node, IDSStructArray):
+        elif isinstance(node, (IDSStructure, IDSStructArray)):
             for subnode in node:
                 self._recursively_find_profiles(subnode)
         else:

--- a/imas_paraview/plugins/vtkggdreader.py
+++ b/imas_paraview/plugins/vtkggdreader.py
@@ -20,18 +20,16 @@ SUPPORTED_IDS_NAMES = [
     "plasma_transport",
 ]
 
-"""
-FIXME: Some IDSs do not have the grid structure in a separate `grid_ggd` object, as
-described by the GGD guidelines. They are for now denoted as experimental IDS, as they
-are currently not covered by the unit tests. If the DD for these stays like this, they
-will need to be handled separately. GGD grid locations for each IDS:
-equilibrium (grids_ggd/grid)
-distribution_sources (source/ggd/grid)
-distributions (distribution/ggd/grid)
-tf (field_map/grid)
-transport_solver_numerics (boundary_conditions_ggd/grid)
-waves (coherent_wave/full_wave/grid)
-"""
+# FIXME: Some IDSs do not have the grid structure in a separate `grid_ggd` object, as
+# described by the GGD guidelines. They are for now denoted as experimental IDS, as they
+# are currently not covered by the unit tests. If the DD for these stays like this, they
+# will need to be handled separately. GGD grid locations for each IDS:
+# equilibrium (grids_ggd/grid)
+# distribution_sources (source/ggd/grid)
+# distributions (distribution/ggd/grid)
+# tf (field_map/grid)
+# transport_solver_numerics (boundary_conditions_ggd/grid)
+# waves (coherent_wave/full_wave/grid)
 
 EXPERIMENTAL_IDS_NAMES = [
     "equilibrium",

--- a/imas_paraview/plugins/vtkggdreader.py
+++ b/imas_paraview/plugins/vtkggdreader.py
@@ -20,16 +20,18 @@ SUPPORTED_IDS_NAMES = [
     "plasma_transport",
 ]
 
-# FIXME: Some IDSs do not have the grid structure in a separate `grid_ggd` object, as
-# described by the GGD guidelines. They are for now denoted as experimental IDS, as they
-# are currently not covered by the unit tests. If the DD for these stays like this, they
-# will need to be handled separately. GGD grid locations for each IDS:
-# equilibrium (grids_ggd/grid)
-# distribution_sources (source/ggd/grid)
-# distributions (distribution/ggd/grid)
-# tf (field_map/grid)
-# transport_solver_numerics (boundary_conditions_ggd/grid)
-# waves (coherent_wave/full_wave/grid)
+"""
+FIXME: Some IDSs do not have the grid structure in a separate `grid_ggd` object, as
+described by the GGD guidelines. They are for now denoted as experimental IDS, as they
+are currently not covered by the unit tests. If the DD for these stays like this, they
+will need to be handled separately. GGD grid locations for each IDS:
+equilibrium (grids_ggd/grid)
+distribution_sources (source/ggd/grid)
+distributions (distribution/ggd/grid)
+tf (field_map/grid)
+transport_solver_numerics (boundary_conditions_ggd/grid)
+waves (coherent_wave/full_wave/grid)
+"""
 
 EXPERIMENTAL_IDS_NAMES = [
     "equilibrium",

--- a/imas_paraview/plugins/wall_limiter.py
+++ b/imas_paraview/plugins/wall_limiter.py
@@ -105,10 +105,7 @@ class WallLimiterReader(GGDVTKPluginBase):
         """
         # closed was removed in DD4 - data providers need to repeat the first point
         # for closed outlines, which Just Works with our is_closed=False logic
-        if getattr(unit, "closed", 0) == 0:
-            is_closed = False
-        else:
-            is_closed = True
+        is_closed = getattr(unit, "closed", 0) != 0
 
         r = unit.outline.r
         z = unit.outline.z

--- a/imas_paraview/plugins/wall_limiter.py
+++ b/imas_paraview/plugins/wall_limiter.py
@@ -51,7 +51,8 @@ class WallLimiterReader(GGDVTKPluginBase):
                 description_name = f"description {i}"
                 logger.warning(
                     "Found a limiter without a description name, "
-                    f"it will be loaded as {description_name}"
+                    "it will be loaded as %s",
+                    description_name,
                 )
 
             limiter = description.limiter
@@ -59,8 +60,8 @@ class WallLimiterReader(GGDVTKPluginBase):
             if type_name == "":
                 type_name = f"type {i}"
                 logger.warning(
-                    "Found a limiter without a type name, "
-                    f"it will be loaded as {type_name}"
+                    "Found a limiter without a type name, it will be loaded as %s",
+                    type_name,
                 )
 
             for j, unit in enumerate(limiter.unit):
@@ -68,8 +69,8 @@ class WallLimiterReader(GGDVTKPluginBase):
                 if unit_name == "":
                     unit_name = f"unit {j}"
                     logger.warning(
-                        "Found a limiter unit without a name, "
-                        f"it will be loaded as {unit_name}"
+                        "Found a limiter unit without a name, it will be loaded as %s",
+                        unit_name,
                     )
                 name = " / ".join(
                     [str(description_name), str(type_name), str(unit_name)]
@@ -86,7 +87,7 @@ class WallLimiterReader(GGDVTKPluginBase):
         """
         for i, limiter_name in enumerate(self._selected):
             limiter = self.selectable_map[limiter_name]
-            logger.info(f"Selected {limiter.name}")
+            logger.info("Selected %s", limiter.name)
             vtk_poly = self._create_contour(limiter)
             output.SetBlock(i, vtk_poly)
 

--- a/imas_paraview/tests/fill_ggd.py
+++ b/imas_paraview/tests/fill_ggd.py
@@ -380,7 +380,7 @@ def fill_ids(ids, time_steps=1, grid_size=2):
 
     # Skip filling grid_ggd if it does not exist
     if grid_ggd is None:
-        logger.warning(f"{ids.metadata.name} has no grid_ggd")
+        logger.warning("%s has no grid_ggd", ids.metadata.name)
     else:
         # Create time steps
         ids.time = [float(t) for t in range(time_steps)]
@@ -399,7 +399,7 @@ def fill_ids(ids, time_steps=1, grid_size=2):
             num_vertices, num_edges, num_faces = fill_NxN_grid(
                 grid_ggd_aos[i], grid_size
             )
-            logger.debug(f"filled grid_ggd at index {i}.")
+            logger.debug("filled grid_ggd at index %d.", i)
         fill_ggd_data(ids, num_vertices, num_edges, num_faces)
 
     fill_ids_specific(ids)

--- a/imas_paraview/tests/fill_ggd.py
+++ b/imas_paraview/tests/fill_ggd.py
@@ -13,7 +13,7 @@ def fill_NxN_grid(grid_ggd, N):
     """Fills the grid_ggd of an IDS with a uniform rectangular grid of size N x N,
     containing vertices, edges and faces.
 
-    Adapted from https://sharepoint.iter.org/departments/POP/CM/IMDesign/Data%20Model/sphinx/3.41/ggd_guide/examples.html # noqa
+    Adapted from https://imas-data-dictionary.readthedocs.io/en/latest/ggd_guide/examples.html
 
     Args:
         grid_ggd: The GGD grid that will be filled with the N x N grid.

--- a/imas_paraview/tests/test_cli.py
+++ b/imas_paraview/tests/test_cli.py
@@ -43,14 +43,16 @@ def test_ggd2vtk(tmp_path, dummy_ids):
     result = runner.invoke(convert_ggd_to_vtk, args)
     assert result.exit_code == 0
 
-    # The vtkXMLPartitionedDataSetCollectionWriter will output the following:
-    # .
-    # ├── test
-    # │   ├── test_0_0.vtu
-    # │   ├── test_1_0.vtu
-    # │   ├── test_2_0.vtu
-    # |   ├── ...
-    # └── test.vtpc
+    """
+    The vtkXMLPartitionedDataSetCollectionWriter will output the following:
+    .
+    ├── test
+    │   ├── test_0_0.vtu
+    │   ├── test_1_0.vtu
+    │   ├── test_2_0.vtu
+    │   ├── ...
+    └── test.vtpc
+    """
 
     # Check if vtpc file and the directory containing vtu files exists
     assert output_path.is_dir()

--- a/imas_paraview/tests/test_cli.py
+++ b/imas_paraview/tests/test_cli.py
@@ -43,16 +43,14 @@ def test_ggd2vtk(tmp_path, dummy_ids):
     result = runner.invoke(convert_ggd_to_vtk, args)
     assert result.exit_code == 0
 
-    """
-    The vtkXMLPartitionedDataSetCollectionWriter will output the following:
-    .
-    ├── test
-    │   ├── test_0_0.vtu
-    │   ├── test_1_0.vtu
-    │   ├── test_2_0.vtu
-    │   ├── ...
-    └── test.vtpc
-    """
+    # The vtkXMLPartitionedDataSetCollectionWriter will output the following:
+    # .
+    # ├── test
+    # │   ├── test_0_0.vtu
+    # │   ├── test_1_0.vtu
+    # │   ├── test_2_0.vtu
+    # │   ├── ...
+    # └── test.vtpc
 
     # Check if vtpc file and the directory containing vtu files exists
     assert output_path.is_dir()

--- a/imas_paraview/tests/test_line_of_sight.py
+++ b/imas_paraview/tests/test_line_of_sight.py
@@ -84,7 +84,7 @@ def test_load_los_ece(test_data_dir):
         reader._selected = [str(channel.name) for channel in ids.channel]
         reader._load_los(output)
         assert output.GetNumberOfBlocks() == len(ids.channel)
-        for i, channel in enumerate(ids.channel):
+        for i in range(len(ids.channel)):
             assert_values_match(los, output.GetBlock(i))
 
 

--- a/imas_paraview/util.py
+++ b/imas_paraview/util.py
@@ -31,9 +31,11 @@ def get_ggd_grid_path(ids_metadata) -> Optional[str]:
     # Find the DD node defining the GGD grid:
     for node in iter_metadata_tree(ids_metadata):
         structure_reference = getattr(node, "structure_reference", None)
-        if structure_reference in ["generic_grid_dynamic", "generic_grid_aos3_root"]:
-            if getattr(node, "lifecycle_status", None) != "obsolescent":
-                return node.path_string
+        if (
+            structure_reference in ["generic_grid_dynamic", "generic_grid_aos3_root"]
+            and getattr(node, "lifecycle_status", None) != "obsolescent"
+        ):
+            return node.path_string
     return None  # There are no GGD grids inside this IDS
 
 

--- a/imas_paraview/util.py
+++ b/imas_paraview/util.py
@@ -91,8 +91,9 @@ def get_grid_ggd(ids, time=0, parent_idx=0):
             else:
                 node = node[0]
                 logger.warning(
-                    f"The GGD grid was not found at time index {ggd_idx}, so first "
-                    "grid was loaded instead."
+                    "The GGD grid was not found at time index %d, so first "
+                    "grid was loaded instead.",
+                    ggd_idx,
                 )
         else:
             node = node[parent_idx]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,4 +68,13 @@ local_scheme = "no-local-version"
 exclude = ["imas_paraview/_version.py"]
 
 [tool.ruff.lint]
-select = ["G004"]
+select = [
+    "E", # pycodestyle
+    "F", # Pyflakes
+    "UP", # pyupgrade
+    "B", # flake8-bugbear
+    "SIM", # flake8-simplify
+    "I", # isort
+    "G", # flake8-logging-format
+]
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,3 +66,6 @@ local_scheme = "no-local-version"
 
 [tool.ruff]
 exclude = ["imas_paraview/_version.py"]
+
+[tool.ruff.lint]
+select = ["G004"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,8 +81,6 @@ select = [
     "SIM",
     # isort
     "I",
-    # eradicate
-    "ERA",
     # flake8-comprehensions
     "C4",
     # flake8-logging

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,12 +69,33 @@ exclude = ["imas_paraview/_version.py"]
 
 [tool.ruff.lint]
 select = [
-    "E", # pycodestyle
-    "F", # Pyflakes
-    "UP", # pyupgrade
-    "B", # flake8-bugbear
-    "SIM", # flake8-simplify
-    "I", # isort
-    "G", # flake8-logging-format
+    # pycodestyle
+    "E",
+    # Pyflakes
+    "F",
+    # pyupgrade
+    "UP",
+    # flake8-bugbear
+    "B",
+    # flake8-simplify
+    "SIM",
+    # isort
+    "I",
+    # eradicate
+    "ERA",
+    # flake8-comprehensions
+    "C4",
+    # flake8-logging
+    "LOG",
+    # flake8-logging-format
+    "G",
+    # flake8-tidy-imports
+    "TID",
+    # flake8-use-pathlib
+    "PTH",
+    # Refurb
+    "FURB",
+    # Ruff specific rules
+    "RUF",
 ]
 


### PR DESCRIPTION
This enables the following linting rules in ruff:
```
# pycodestyle
"E",
# Pyflakes
"F",
# pyupgrade
"UP",
# flake8-bugbear
"B",
# flake8-simplify
"SIM",
# isort
"I",
# eradicate
"ERA",
# flake8-comprehensions
"C4",
# flake8-logging
"LOG",
# flake8-logging-format
"G",
# flake8-tidy-imports
"TID",
# flake8-use-pathlib
"PTH",
# Refurb
"FURB",
# Ruff specific rules
"RUF",
```