### PR TITLE
Add identifier number if AoS does not contain a label

### DIFF
--- a/imas_paraview/ids_util.py
+++ b/imas_paraview/ids_util.py
@@ -103,21 +103,18 @@ def recursive_ggd_path_search(
         )
 
 
-def is_child_of_time_dependent_aos(node):
-    """Returns True if the provided IDS node is a child of a time-dependent AoS,
+def is_time_dependent_aos(node):
+    """Returns True if the provided IDS node is a time-dependent AoS,
     and False otherwise.
 
-    Examples of children of a time-dependent AoSs:
-    - equilibrium/time_slice[0]
-    - core_sources/source[0]/global_quantities[1]
-    - core_profiles/profiles_1d[2]
+    Examples of time-dependent AoSs:
+    - equilibrium/time_slice
+    - core_sources/source[0]/global_quantities
+    - core_profiles/profiles_1d
     """
-    parent = imas.util.get_parent(node)
     return (
-        hasattr(node.metadata, "coordinate1")
+        isinstance(node, IDSStructArray)
         and node.metadata.coordinate1.is_time_coordinate
-        and hasattr(parent.metadata, "coordinate1")
-        and parent.metadata.coordinate1.is_time_coordinate
     )
 
 
@@ -137,7 +134,7 @@ def create_name_recursive(node):
     name = ""
     parent = imas.util.get_parent(node)
     # skip time slice quantity
-    if not is_child_of_time_dependent_aos(node):
+    if not is_time_dependent_aos(parent):
         if isinstance(parent, IDSStructArray):
             name_appendix = ""
             # Check if node has an identifier.name

--- a/imas_paraview/ids_util.py
+++ b/imas_paraview/ids_util.py
@@ -138,30 +138,27 @@ def create_name_recursive(node):
     parent = imas.util.get_parent(node)
     # skip time slice quantity
     if not is_child_of_time_dependent_aos(node):
-        name_appendix = ""
+        if isinstance(parent, IDSStructArray):
+            name_appendix = ""
+            # Check if node has an identifier.name
+            if hasattr(node, "identifier") and hasattr(node.identifier, "name"):
+                name_appendix = str(node.identifier.name).strip()
 
-        # Check if node has an identifier.name
-        if hasattr(node, "identifier") and hasattr(node.identifier, "name"):
-            name_appendix = str(node.identifier.name).strip()
+            # Check if node has a name
+            elif hasattr(node, "name"):
+                name_appendix = str(node.name).strip()
 
-        # Check if node has a name
-        elif hasattr(node, "name"):
-            name_appendix = str(node.name).strip()
+            # Check if node has a label
+            elif hasattr(node, "label"):
+                name_appendix = str(node.label.value).strip()
 
-        # Check if node has a label
-        elif hasattr(node, "label"):
-            name_appendix = str(node.label.value).strip()
-
-        # Add identifier if AoS has no name to ensure uniqueness
-        elif isinstance(parent, IDSStructArray):
-            # NOTE: This is O(N) in the size of the AoS
-            for index, child in enumerate(parent):
-                if child is node:
-                    name_appendix = f"#{index + 1}"
-                    break
-
-        # Add identifier/name/label in between brackets to the full name
-        if name_appendix != "":
+            # Add identifier if AoS has no name to ensure uniqueness
+            if name_appendix == "":
+                # NOTE: This is O(N) in the size of the AoS
+                for index, child in enumerate(parent):
+                    if child is node:
+                        name_appendix = f"#{index + 1}"
+                        break
             name = f"{name_current_node.capitalize()} ({name_appendix.capitalize()})"
         else:
             name = name_current_node.capitalize()

--- a/imas_paraview/ids_util.py
+++ b/imas_paraview/ids_util.py
@@ -1,5 +1,6 @@
 import imas
 from imas.ids_data_type import IDSDataType
+from imas.ids_struct_array import IDSStructArray
 from imas.ids_toplevel import IDSToplevel
 
 from imas_paraview._ids_util import _get_nodes_from_path
@@ -102,6 +103,24 @@ def recursive_ggd_path_search(
         )
 
 
+def is_child_of_time_dependent_aos(node):
+    """Returns True if the provided IDS node is a child of a time-dependent AoS,
+    and False otherwise.
+
+    Examples of children of a time-dependent AoSs:
+    - equilibrium/time_slice[0]
+    - core_sources/source[0]/global_quantities[1]
+    - core_profiles/profiles_1d[2]
+    """
+    parent = imas.util.get_parent(node)
+    return (
+        hasattr(node.metadata, "coordinate1")
+        and node.metadata.coordinate1.is_time_coordinate
+        and hasattr(parent.metadata, "coordinate1")
+        and parent.metadata.coordinate1.is_time_coordinate
+    )
+
+
 def create_name_recursive(node):
     """Generates a name for an IDS node. The parents of the node are
     searched recursively until the IDS toplevel is reached. The name of the metadata
@@ -116,12 +135,9 @@ def create_name_recursive(node):
     """
     name_current_node = node.metadata.name
     name = ""
-    if (
-        name_current_node != "ggd"
-        and name_current_node != "profiles_1d"
-        and name_current_node != "profiles_2d"
-        and "time_slice" not in name_current_node
-    ):
+    parent = imas.util.get_parent(node)
+    # skip time slice quantity
+    if not is_child_of_time_dependent_aos(node):
         name_appendix = ""
 
         # Check if node has an identifier.name
@@ -136,13 +152,20 @@ def create_name_recursive(node):
         elif hasattr(node, "label"):
             name_appendix = str(node.label.value).strip()
 
+        # Add identifier if AoS has no name to ensure uniqueness
+        elif isinstance(parent, IDSStructArray):
+            # NOTE: This is O(N) in the size of the AoS
+            for index, child in enumerate(parent):
+                if child is node:
+                    name_appendix = f"#{index + 1}"
+                    break
+
         # Add identifier/name/label in between brackets to the full name
         if name_appendix != "":
             name = f"{name_current_node.capitalize()} ({name_appendix.capitalize()})"
         else:
             name = name_current_node.capitalize()
 
-    parent = imas.util.get_parent(node)
     if parent.metadata is node.metadata:
         parent = imas.util.get_parent(parent)
     if not isinstance(parent, IDSToplevel):

--- a/imas_paraview/tests/test_ids_util.py
+++ b/imas_paraview/tests/test_ids_util.py
@@ -5,7 +5,7 @@ from imas.ids_path import IDSPath
 from imas_paraview.ids_util import (
     create_name_recursive,
     get_arrays_from_ids,
-    is_child_of_time_dependent_aos,
+    is_time_dependent_aos,
     recursive_ggd_path_search,
 )
 from imas_paraview.tests.fill_ggd import fill_scalar_quantity, fill_vector_quantity
@@ -178,15 +178,15 @@ def test_create_name_recursive_aos_no_label():
     assert name3 == "Constraints B_field_pol_probe (#3) Measured"
 
 
-def test_is_child_of_time_dependent_aos():
+def test_time_dependent_aos():
     ids = imas.IDSFactory(version="4.1.0").new("equilibrium")
-    assert not is_child_of_time_dependent_aos(ids)
+    assert not is_time_dependent_aos(ids)
     ids.time_slice.resize(1)
-    assert not is_child_of_time_dependent_aos(ids.time_slice)
-    assert is_child_of_time_dependent_aos(ids.time_slice[0])
-    assert not is_child_of_time_dependent_aos(ids.time_slice[0].boundary)
-    assert not is_child_of_time_dependent_aos(ids.time_slice[0].boundary)
+    assert is_time_dependent_aos(ids.time_slice)
+    assert not is_time_dependent_aos(ids.time_slice[0])
+    assert not is_time_dependent_aos(ids.time_slice[0].boundary)
+    assert not is_time_dependent_aos(ids.time_slice[0].boundary)
     ids.time_slice[0].boundary.gap.resize(1)
-    assert not is_child_of_time_dependent_aos(ids.time_slice[0].boundary.gap)
-    assert not is_child_of_time_dependent_aos(ids.time_slice[0].boundary.gap[0])
-    assert not is_child_of_time_dependent_aos(ids.time_slice[0].boundary.gap[0].r)
+    assert not is_time_dependent_aos(ids.time_slice[0].boundary.gap)
+    assert not is_time_dependent_aos(ids.time_slice[0].boundary.gap[0])
+    assert not is_time_dependent_aos(ids.time_slice[0].boundary.gap[0].r)

--- a/imas_paraview/tests/test_ids_util.py
+++ b/imas_paraview/tests/test_ids_util.py
@@ -5,6 +5,7 @@ from imas.ids_path import IDSPath
 from imas_paraview.ids_util import (
     create_name_recursive,
     get_arrays_from_ids,
+    is_child_of_time_dependent_aos,
     recursive_ggd_path_search,
 )
 from imas_paraview.tests.fill_ggd import fill_scalar_quantity, fill_vector_quantity
@@ -158,3 +159,34 @@ def test_create_name_recursive_profiles():
     assert create_name_recursive(electrons_pressure) == "Electrons Pressure"
     assert create_name_recursive(temperature) == "Ion (D) Temperature"
     assert create_name_recursive(density) == "Ion (T) Density"
+
+
+def test_create_name_recursive_aos_no_label():
+    ids = imas.IDSFactory(version="4.1.0").new("equilibrium")
+    ids.time_slice.resize(1)
+    ids.time_slice[0].constraints.b_field_pol_probe.resize(3)
+    array1 = ids.time_slice[0].constraints.b_field_pol_probe[0].measured
+    array2 = ids.time_slice[0].constraints.b_field_pol_probe[1].measured
+    array3 = ids.time_slice[0].constraints.b_field_pol_probe[2].measured
+
+    name1 = create_name_recursive(array1)
+    name2 = create_name_recursive(array2)
+    name3 = create_name_recursive(array3)
+
+    assert name1 == "Constraints B_field_pol_probe (#1) Measured"
+    assert name2 == "Constraints B_field_pol_probe (#2) Measured"
+    assert name3 == "Constraints B_field_pol_probe (#3) Measured"
+
+
+def test_is_child_of_time_dependent_aos():
+    ids = imas.IDSFactory(version="4.1.0").new("equilibrium")
+    assert not is_child_of_time_dependent_aos(ids)
+    ids.time_slice.resize(1)
+    assert not is_child_of_time_dependent_aos(ids.time_slice)
+    assert is_child_of_time_dependent_aos(ids.time_slice[0])
+    assert not is_child_of_time_dependent_aos(ids.time_slice[0].boundary)
+    assert not is_child_of_time_dependent_aos(ids.time_slice[0].boundary)
+    ids.time_slice[0].boundary.gap.resize(1)
+    assert not is_child_of_time_dependent_aos(ids.time_slice[0].boundary.gap)
+    assert not is_child_of_time_dependent_aos(ids.time_slice[0].boundary.gap[0])
+    assert not is_child_of_time_dependent_aos(ids.time_slice[0].boundary.gap[0].r)

--- a/imas_paraview/tests/test_profiles_2d.py
+++ b/imas_paraview/tests/test_profiles_2d.py
@@ -21,9 +21,9 @@ def test_load_profiles(test_data_dir):
         reader.setup_ids()
 
         profile1 = ids.time_slice[0].profiles_2d[0].psi
-        name1 = "Psi"
+        name1 = "Profiles_2d (#1) Psi"
         profile2 = ids.time_slice[0].profiles_2d[0].b_field_phi
-        name2 = "B_field_phi"
+        name2 = "Profiles_2d (#1) B_field_phi"
         # 1 selection
         output = vtkPartitionedDataSetCollection()
         reader._selected = [name1]
@@ -70,7 +70,7 @@ def test_load_profiles_dummy_equilibrium():
     reader._ids = ids
     reader.setup_ids()
     output = vtkPartitionedDataSetCollection()
-    reader._selected = ["Psi"]
+    reader._selected = ["Profiles_2d (#1) Psi"]
     reader._load_profiles(output)
     assert output.GetNumberOfPartitionedDataSets() == 1
     profile = ids.time_slice[0].profiles_2d[0].psi

--- a/imas_paraview/tests/test_profiles_2d.py
+++ b/imas_paraview/tests/test_profiles_2d.py
@@ -93,7 +93,7 @@ def test_load_profiles_dummy_core_profiles():
     reader._ids = ids
     reader.setup_ids()
     output = vtkPartitionedDataSetCollection()
-    reader._selected = ["Ion Pressure"]
+    reader._selected = ["Ion (#1) Pressure"]
     reader._load_profiles(output)
     assert output.GetNumberOfPartitionedDataSets() == 1
     profile = profiles_2d.ion[0].pressure


### PR DESCRIPTION
If an AoS did not contain an identifier label (e.g. `identifier`, `name`, `label`), the same name would be generated for the different children of the AoS, and as a result earlier loaded data would be lost when loading it into ParaView. 

This adds an identifier number behind the AoS name to ensure uniqueness of the given name. 