### PR TITLE
Add support for VTK to GGD conversion

### DIFF
--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -144,14 +144,14 @@ VTK File Format Requirements
 
 The ``vtk2ggd`` converter has specific requirements for the VTK input files it can process:
 
-* The converter expects VTK Partitioned Dataset Collection (``.vtpc``) files in XML format
-* The converter can handle either:
+* The converter can convert the following VTK files in the XML format:
   
-  - A single ``.vtpc`` file containing a single time step conversion
+  - A single ``.vtu`` file containing a vtkUnstructuredGrid.
+  - A single ``.vtpc`` file containing a vtkPartitionedDataSetCollection with a single time step
   - A directory containing a file series of ``.vtpc`` files (e.g., ``edge_profiles_0.vtpc``, 
     ``edge_profiles_1.vtpc``, etc.), one for each time step.
 
-* Each ``vtkPartitionedDataSet`` should contain **exactly one partition** containing a ``vtkUnstructuredGrid``, otherwise the 
+* When providing ``.vtpc`` files, each ``vtkPartitionedDataSet`` should contain **exactly one partition** containing a ``vtkUnstructuredGrid``, otherwise the 
   partition is skipped. Each ``vtkUnstructuredGrid`` will be converted into a separate grid subset in the GGD.
 
 Limitations of VTK grid conversion
@@ -162,6 +162,6 @@ The converter can only output IDSs with:
 * a `linear <https://imas-data-dictionary.readthedocs.io/en/latest/generated/identifier/ggd_identifier.html>`_ GGD grid.
 * a single `space of a GGD grid <https://imas-data-dictionary.readthedocs.io/en/latest/generated/ids/edge_profiles.html#edge_profiles-grid_ggd-space>`_.
 * `standard space geometries <https://imas-data-dictionary.readthedocs.io/en/latest/generated/ids/edge_profiles.html#edge_profiles-grid_ggd-space-geometry_type>`_, not Fourier spaces.
-* X, Y, Z coordinates (`coordinate_identifier.x/y/z <https://imas-data-dictionary.readthedocs.io/en/latest/generated/identifier/coordinate_identifier.html>`_).
+* X, Y, Z coordinates (`coordinate_identifier.x/y/z <https://imas-data-dictionary.readthedocs.io/en/latest/generated/identifier/coordinate_identifier.html>`_), or R, Phi, Z coordinates (when the ``--cylindrical_coordinates`` flag is enabled).
 * the GGD grid structure itself, not any physical quantities (temperature, density, etc.) defined on the grids in the `ggd <https://imas-data-dictionary.readthedocs.io/en/latest/generated/ids/edge_profiles.html#edge_profiles-ggd>`_ AoS.
 * a homogeneous time mode.

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -152,7 +152,7 @@ The ``vtk2ggd`` converter has specific requirements for the VTK input files it c
     ``edge_profiles_1.vtpc``, etc.), one for each time step.
 
 * Each ``vtkPartitionedDataSet`` should contain **exactly one partition** containing a ``vtkUnstructuredGrid``, otherwise the 
-  partition is skipped. Each ``vtkUnstructuredGrid`` will be converted into a separate grid subset in the GGD
+  partition is skipped. Each ``vtkUnstructuredGrid`` will be converted into a separate grid subset in the GGD.
 
 Limitations of VTK grid conversion
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -107,3 +107,61 @@ To convert all time steps that fall between 2.2s and 6.6s:
 .. note:: If the specified time step is not found in the IDS, the time step before the
    specified time step will be used instead.
 
+
+Convert VTK to GGD grids using the CLI
+--------------------------------------
+
+IMAS-ParaView supports converting VTK files to GGD grids in an IDS using the ``vtk2ggd`` command-line tool.
+
+.. tip:: Detailed usage of the CLI tool can be found by running ``vtk2ggd --help``
+
+Usage
+^^^^^
+
+The ``vtk2ggd`` command requires two arguments: the path to VTK files and the output URI where the IDS will be stored.
+
+**Single file conversion:**
+
+.. code-block:: bash
+
+    vtk2ggd example.vtpc imas:hdf5?path=output_db --ids_name edge_profiles
+
+This converts a single ``.vtpc`` file to an IDS, at the given URI.
+
+**File series conversion:**
+
+.. code-block:: bash
+
+    vtk2ggd output_dir/ imas:hdf5?path=output_db
+
+This converts all ``.vtpc`` files in the specified directory to a single IDS with multiple time steps. The files
+should be named following the pattern ``{ids_name}_0.vtpc``, ``{ids_name}_1.vtpc``, etc. The IDS name will be 
+automatically inferred from the file names.
+
+
+VTK File Format Requirements
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The ``vtk2ggd`` converter has specific requirements for the VTK input files it can process:
+
+* The converter expects VTK Partitioned Dataset Collection (``.vtpc``) files in XML format
+* The converter can handle either:
+  
+  - A single ``.vtpc`` file containing a single time step conversion
+  - A directory containing a file series of ``.vtpc`` files (e.g., ``edge_profiles_0.vtpc``, 
+    ``edge_profiles_1.vtpc``, etc.), one for each time step.
+
+* Each ``vtkPartitionedDataSet`` should contain **exactly one partition** containing a ``vtkUnstructuredGrid``, otherwise the 
+  partition is skipped. Each ``vtkUnstructuredGrid`` will be converted into a separate grid subset in the GGD
+
+Limitations of VTK grid conversion
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The converter can only output IDSs with:
+
+* a `linear <https://imas-data-dictionary.readthedocs.io/en/latest/generated/identifier/ggd_identifier.html>`_ GGD grid.
+* a single `space of a GGD grid <https://imas-data-dictionary.readthedocs.io/en/latest/generated/ids/edge_profiles.html#edge_profiles-grid_ggd-space>`_.
+* `standard space geometries <https://imas-data-dictionary.readthedocs.io/en/latest/generated/ids/edge_profiles.html#edge_profiles-grid_ggd-space-geometry_type>`_, not Fourier spaces.
+* X, Y, Z coordinates (`coordinate_identifier.x/y/z <https://imas-data-dictionary.readthedocs.io/en/latest/generated/identifier/coordinate_identifier.html>`_).
+* the GGD grid structure itself, not any physical quantities (temperature, density, etc.) defined on the grids in the `ggd <https://imas-data-dictionary.readthedocs.io/en/latest/generated/ids/edge_profiles.html#edge_profiles-ggd>`_ AoS.
+* a homogeneous time mode.

--- a/imas_paraview/cli.py
+++ b/imas_paraview/cli.py
@@ -250,7 +250,7 @@ def convert_vtk_to_ggd(path, uri, ids_name, dd_version):
                 entry._dbe_impl.access_layer_version()
             )
             version_put = ids.ids_properties.version_put
-            version_put.data_dictionary = dd_version
+            version_put.data_dictionary = entry.dd_version
             version_put.access_layer_language = f"IMAS-Python {imas.__version__}"
         entry.put(ids)
 

--- a/imas_paraview/cli.py
+++ b/imas_paraview/cli.py
@@ -197,7 +197,12 @@ def convert_ggd_to_vtk(
     type=str,
     help="Specify the version of the Data Dictionary to export the IDS to.",
 )
-def convert_vtk_to_ggd(path, uri, ids_name, dd_version):
+@click.option(
+    "--cylindrical_coordinates",
+    is_flag=True,
+    help="Store GGD grid in cylindrical coordinates instead of cartesian.",
+)
+def convert_vtk_to_ggd(path, uri, ids_name, dd_version, cylindrical_coordinates):
     """Convert a file series of .vtpc files, or a single .vtpc containing
     unstructured grids to a GGD grid in an IDS.
 
@@ -250,7 +255,12 @@ def convert_vtk_to_ggd(path, uri, ids_name, dd_version):
     click.echo(f"Converting {len(vtpc_files)} time steps for IDS '{ids_name}'...")
 
     vtk_objects = [load_vtpc(f) for f in vtpc_files]
-    converter = VTK2GGDConverter(vtk_objects, ids_name, dd_version)
+    converter = VTK2GGDConverter(
+        vtk_objects,
+        ids_name,
+        dd_version=dd_version,
+        cylindrical_coordinates=cylindrical_coordinates,
+    )
     ids = converter.convert()
 
     with imas.DBEntry(uri, "x", dd_version=dd_version) as entry:

--- a/imas_paraview/cli.py
+++ b/imas_paraview/cli.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import click
 import imas
+import imas.backends.imas_core.imas_interface
 from imas.backends.imas_core.imas_interface import ll_interface
 from rich import box, console, traceback
 from rich.table import Table
@@ -243,10 +244,14 @@ def convert_vtk_to_ggd(path, uri, ids_name, dd_version):
     ids = converter.convert()
 
     with imas.DBEntry(uri, "x", dd_version=dd_version) as entry:
+        # Set version_put properties (version_put was added in DD 3.22)
         if hasattr(ids.ids_properties, "version_put"):
             ids.ids_properties.version_put.access_layer = (
                 entry._dbe_impl.access_layer_version()
             )
+            version_put = ids.ids_properties.version_put
+            version_put.data_dictionary = dd_version
+            version_put.access_layer_language = f"IMAS-Python {imas.__version__}"
         entry.put(ids)
 
     click.echo(f"Successfully wrote {len(vtpc_files)} time steps to {uri}")

--- a/imas_paraview/cli.py
+++ b/imas_paraview/cli.py
@@ -5,14 +5,14 @@ from pathlib import Path
 
 import click
 import imas
-import imas.backends.imas_core.imas_interface
 from imas.backends.imas_core.imas_interface import ll_interface
 from rich import box, console, traceback
 from rich.table import Table
 
 import imas_paraview
 from imas_paraview.convert import Converter
-from imas_paraview.util import find_closest_indices
+from imas_paraview.util import find_closest_indices, load_vtpc
+from imas_paraview.vtk2ggd import VTK2GGDConverter
 
 logger = logging.getLogger(__name__)
 
@@ -181,6 +181,64 @@ def convert_ggd_to_vtk(
 
         elif format == "vtkhdf":
             raise NotImplementedError("vtkhdf format is not yet implemented.")
+
+
+@cli.command("vtk2ggd")
+@click.argument("input_path", type=Path)
+@click.argument("output_uri", type=str)
+@click.option(
+    "--ids_name",
+    "-n",
+    type=str,
+    help="Name of the IDS (e.g., 'edge_profiles'). If not provided, it will be inferred from filenames.",
+)
+@click.option(
+    "--dd_version",
+    type=str,
+    help="Specify the version of the Data Dictionary.",
+)
+def convert_vtk_to_ggd(input_path, output_uri, ids_name, dd_version):
+    """Convert VTK files (single or directory) back to a single IMAS IDS."""
+    sys.excepthook = _excepthook
+
+    vtpc_files = []
+
+    if input_path.is_dir():
+        click.echo(f"Scanning directory {input_path} for VTK files...")
+        # Find all .vtpc files and sort them by the trailing index (e.g., _0, _1)
+        vtpc_files = sorted(
+            list(input_path.glob("*.vtpc")),
+            key=lambda x: int(x.stem.split("_")[-1]) if "_" in x.stem else 0,
+        )
+        if not vtpc_files:
+            raise click.UsageError(f"No .vtpc files found in {input_path}")
+
+        # Infer ids_name from the first file (edge_profiles_0.vtpc -> edge_profiles)
+        if not ids_name:
+            ids_name = vtpc_files[0].stem.rsplit("_", 1)[0]
+    else:
+        vtpc_files = [input_path]
+        if not ids_name:
+            raise click.UsageError(
+                "Argument '--ids_name' is required for single file conversion."
+            )
+
+    click.echo(f"Converting {len(vtpc_files)} time steps for IDS '{ids_name}'...")
+
+    vtk_objects = [load_vtpc(f) for f in vtpc_files]
+
+    converter = VTK2GGDConverter(vtk_objects, ids_name, dd_version)
+    ids = converter.convert()
+
+    with imas.DBEntry(output_uri, "x", dd_version=dd_version) as entry:
+        # TODO: is this exposed in IMAS-Python API or is there another way to set this?
+        if hasattr(ids.ids_properties, "version_put"):
+            ids.ids_properties.version_put.access_layer = (
+                entry._dbe_impl.access_layer_version()
+            )
+        entry.put(ids)
+
+    click.echo(f"Successfully wrote {len(vtpc_files)} time steps to {output_uri}")
 
 
 def is_lazy(all_times, lazy_flag, no_lazy_flag):

--- a/imas_paraview/cli.py
+++ b/imas_paraview/cli.py
@@ -12,7 +12,7 @@ from rich.table import Table
 
 import imas_paraview
 from imas_paraview.convert import Converter
-from imas_paraview.util import find_closest_indices, load_vtpc
+from imas_paraview.util import find_closest_indices, load_vtpc, load_vtu
 from imas_paraview.vtk2ggd import VTK2GGDConverter
 
 logger = logging.getLogger(__name__)
@@ -203,58 +203,26 @@ def convert_ggd_to_vtk(
     help="Store GGD grid in cylindrical coordinates instead of cartesian.",
 )
 def convert_vtk_to_ggd(path, uri, ids_name, dd_version, cylindrical_coordinates):
-    """Convert a file series of .vtpc files, or a single .vtpc containing
-    unstructured grids to a GGD grid in an IDS.
+    """Convert a file series of .vtpc files, a single .vtpc, or a single .vtu file
+    containing unstructured grids to a GGD grid in an IDS.
 
     \b
     Arguments:
     \b
-    path            Path to a single .vtpc file, or to the directory containing a series
-                    of .vtpc files.
+    path            Path to a single .vtpc/.vtu file, or to the directory containing a
+                    file series of .vtpc files.
     uri             Output URI to store the IDS.
     """
     sys.excepthook = _excepthook
 
-    vtpc_files = []
-
-    if path.is_dir():  # The input is a file series
-        click.echo(f"Scanning directory {path} for VTK files...")
-        # Find all .vtpc files and sort them by the trailing index (e.g., _0, _1)
-        string_match = f"{ids_name}_*.vtpc" if ids_name else "*.vtpc"
-
-        vtpc_files = sorted(
-            path.glob(string_match),
-            key=lambda x: int(x.stem.split("_")[-1]) if "_" in x.stem else 0,
-        )
-        if not vtpc_files:
-            raise click.UsageError(f"No .vtpc files found in {path}")
-
-        # Infer ids_name from the file names (edge_profiles_0.vtpc -> edge_profiles)
-        if not ids_name:
-            ids_names = set()
-            for vtpc_file in vtpc_files:
-                ids_names.add(vtpc_file.stem.rsplit("_", 1)[0])
-                if len(ids_names) > 1:
-                    raise click.UsageError(
-                        "Could not infer IDS name from file names, because there are "
-                        "multiple IDS names in the directory. Use '--ids_name' to set "
-                        "the required IDS name"
-                    )
-
-            (ids_name,) = ids_names
+    if path.suffix == ".vtu":
+        vtk_objects = _load_vtu_file(path, ids_name)
     else:
-        if not ids_name:
-            raise click.UsageError(
-                "Argument '--ids_name' is required for single file conversion."
-            )
-        vtpc_files = [path]
+        vtk_objects, ids_name = _load_vtpc_files(path, ids_name)
 
     if ids_name not in imas.IDSFactory().ids_names():
         raise click.UsageError(f"{ids_name} is not a valid IDS name")
 
-    click.echo(f"Converting {len(vtpc_files)} time steps for IDS '{ids_name}'...")
-
-    vtk_objects = [load_vtpc(f) for f in vtpc_files]
     converter = VTK2GGDConverter(
         vtk_objects,
         ids_name,
@@ -266,7 +234,52 @@ def convert_vtk_to_ggd(path, uri, ids_name, dd_version, cylindrical_coordinates)
     with imas.DBEntry(uri, "x", dd_version=dd_version) as entry:
         entry.put(ids)
 
-    click.echo(f"Successfully wrote {len(vtpc_files)} time steps to {uri}")
+    click.echo(f"Successfully wrote {len(vtk_objects)} time steps to {uri}")
+
+
+def _load_vtu_file(path, ids_name):
+    if not ids_name:
+        raise click.UsageError(
+            "Argument '--ids_name' is required for single file conversion."
+        )
+
+    click.echo(f"Converting single .vtu file to IDS '{ids_name}'...")
+    return [load_vtu(path)]
+
+
+def _load_vtpc_files(path, ids_name):
+    vtpc_files = []
+
+    if path.is_dir():
+        click.echo(f"Scanning directory {path} for VTK files...")
+        string_match = f"{ids_name}_*.vtpc" if ids_name else "*.vtpc"
+        vtpc_files = sorted(
+            path.glob(string_match),
+            key=lambda x: int(x.stem.split("_")[-1]) if "_" in x.stem else 0,
+        )
+        if not vtpc_files:
+            raise click.UsageError(f"No .vtpc files found in {path}")
+
+        if not ids_name:
+            ids_names = set()
+            for vtpc_file in vtpc_files:
+                ids_names.add(vtpc_file.stem.rsplit("_", 1)[0])
+                if len(ids_names) > 1:
+                    raise click.UsageError(
+                        "Could not infer IDS name from file names, because there are "
+                        "multiple IDS names in the directory. Use '--ids_name' to set "
+                        "the required IDS name"
+                    )
+            (ids_name,) = ids_names
+    else:
+        if not ids_name:
+            raise click.UsageError(
+                "Argument '--ids_name' is required for single file conversion."
+            )
+        vtpc_files = [path]
+
+    click.echo(f"Converting {len(vtpc_files)} time steps for IDS '{ids_name}'...")
+    return [load_vtpc(f) for f in vtpc_files], ids_name
 
 
 def is_lazy(all_times, lazy_flag, no_lazy_flag):

--- a/imas_paraview/cli.py
+++ b/imas_paraview/cli.py
@@ -184,41 +184,53 @@ def convert_ggd_to_vtk(
 
 
 @cli.command("vtk2ggd")
-@click.argument("input_path", type=Path)
-@click.argument("output_uri", type=str)
+@click.argument("path", type=Path)
+@click.argument("uri", type=str)
 @click.option(
     "--ids_name",
-    "-n",
     type=str,
-    help="Name of the IDS (e.g., 'edge_profiles'). If not provided, it will be "
-    "inferred from filenames.",
+    help="Name of the IDS, if not provided, it will be inferred from filenames.",
 )
 @click.option(
     "--dd_version",
     type=str,
-    help="Specify the version of the Data Dictionary.",
+    help="Specify the version of the Data Dictionary to export the IDS to.",
 )
-def convert_vtk_to_ggd(input_path, output_uri, ids_name, dd_version):
-    """Convert vtkPartitionedDatasetCollections to a GGD grid in IDS."""
+def convert_vtk_to_ggd(path, uri, ids_name, dd_version):
+    """Convert a file series of .vtpc files, or a single .vtpc containing
+    unstructured grids to a GGD grid in an IDS.
+
+    \b
+    Arguments:
+    \b
+    path            Path to a single .vtpc file, or to the directory containing a series
+                    of .vtpc files.
+    uri             Output URI to store the IDS.
+    """
     sys.excepthook = _excepthook
 
     vtpc_files = []
 
-    if input_path.is_dir():
-        click.echo(f"Scanning directory {input_path} for VTK files...")
+    if path.is_dir():  # The input is a file series
+        click.echo(f"Scanning directory {path} for VTK files...")
         # Find all .vtpc files and sort them by the trailing index (e.g., _0, _1)
         vtpc_files = sorted(
-            input_path.glob("*.vtpc"),
+            path.glob("*.vtpc"),
             key=lambda x: int(x.stem.split("_")[-1]) if "_" in x.stem else 0,
         )
         if not vtpc_files:
-            raise click.UsageError(f"No .vtpc files found in {input_path}")
+            raise click.UsageError(f"No .vtpc files found in {path}")
 
         # Infer ids_name from the first file (edge_profiles_0.vtpc -> edge_profiles)
         if not ids_name:
             ids_name = vtpc_files[0].stem.rsplit("_", 1)[0]
+            if ids_name not in imas.IDSFactory().ids_names():
+                raise click.UsageError(
+                    f"Could not infer IDS name from file names: {ids_name} is not a "
+                    "valid IDS name. Use '--ids_name' to set the required IDS name"
+                )
     else:
-        vtpc_files = [input_path]
+        vtpc_files = [path]
         if not ids_name:
             raise click.UsageError(
                 "Argument '--ids_name' is required for single file conversion."
@@ -227,19 +239,17 @@ def convert_vtk_to_ggd(input_path, output_uri, ids_name, dd_version):
     click.echo(f"Converting {len(vtpc_files)} time steps for IDS '{ids_name}'...")
 
     vtk_objects = [load_vtpc(f) for f in vtpc_files]
-
     converter = VTK2GGDConverter(vtk_objects, ids_name, dd_version)
     ids = converter.convert()
 
-    with imas.DBEntry(output_uri, "x", dd_version=dd_version) as entry:
-        # TODO: is this exposed in IMAS-Python API or is there another way to set this?
+    with imas.DBEntry(uri, "x", dd_version=dd_version) as entry:
         if hasattr(ids.ids_properties, "version_put"):
             ids.ids_properties.version_put.access_layer = (
                 entry._dbe_impl.access_layer_version()
             )
         entry.put(ids)
 
-    click.echo(f"Successfully wrote {len(vtpc_files)} time steps to {output_uri}")
+    click.echo(f"Successfully wrote {len(vtpc_files)} time steps to {uri}")
 
 
 def is_lazy(all_times, lazy_flag, no_lazy_flag):

--- a/imas_paraview/cli.py
+++ b/imas_paraview/cli.py
@@ -190,7 +190,8 @@ def convert_ggd_to_vtk(
     "--ids_name",
     "-n",
     type=str,
-    help="Name of the IDS (e.g., 'edge_profiles'). If not provided, it will be inferred from filenames.",
+    help="Name of the IDS (e.g., 'edge_profiles'). If not provided, it will be "
+    "inferred from filenames.",
 )
 @click.option(
     "--dd_version",
@@ -198,7 +199,7 @@ def convert_ggd_to_vtk(
     help="Specify the version of the Data Dictionary.",
 )
 def convert_vtk_to_ggd(input_path, output_uri, ids_name, dd_version):
-    """Convert VTK files (single or directory) back to a single IMAS IDS."""
+    """Convert vtkPartitionedDatasetCollections to a GGD grid in IDS."""
     sys.excepthook = _excepthook
 
     vtpc_files = []
@@ -207,7 +208,7 @@ def convert_vtk_to_ggd(input_path, output_uri, ids_name, dd_version):
         click.echo(f"Scanning directory {input_path} for VTK files...")
         # Find all .vtpc files and sort them by the trailing index (e.g., _0, _1)
         vtpc_files = sorted(
-            list(input_path.glob("*.vtpc")),
+            input_path.glob("*.vtpc"),
             key=lambda x: int(x.stem.split("_")[-1]) if "_" in x.stem else 0,
         )
         if not vtpc_files:

--- a/imas_paraview/cli.py
+++ b/imas_paraview/cli.py
@@ -215,27 +215,37 @@ def convert_vtk_to_ggd(path, uri, ids_name, dd_version):
     if path.is_dir():  # The input is a file series
         click.echo(f"Scanning directory {path} for VTK files...")
         # Find all .vtpc files and sort them by the trailing index (e.g., _0, _1)
+        string_match = f"{ids_name}_*.vtpc" if ids_name else "*.vtpc"
+
         vtpc_files = sorted(
-            path.glob("*.vtpc"),
+            path.glob(string_match),
             key=lambda x: int(x.stem.split("_")[-1]) if "_" in x.stem else 0,
         )
         if not vtpc_files:
             raise click.UsageError(f"No .vtpc files found in {path}")
 
-        # Infer ids_name from the first file (edge_profiles_0.vtpc -> edge_profiles)
+        # Infer ids_name from the file names (edge_profiles_0.vtpc -> edge_profiles)
         if not ids_name:
-            ids_name = vtpc_files[0].stem.rsplit("_", 1)[0]
-            if ids_name not in imas.IDSFactory().ids_names():
-                raise click.UsageError(
-                    f"Could not infer IDS name from file names: {ids_name} is not a "
-                    "valid IDS name. Use '--ids_name' to set the required IDS name"
-                )
+            ids_names = set()
+            for vtpc_file in vtpc_files:
+                ids_names.add(vtpc_file.stem.rsplit("_", 1)[0])
+                if len(ids_names) > 1:
+                    raise click.UsageError(
+                        "Could not infer IDS name from file names, because there are "
+                        "multiple IDS names in the directory. Use '--ids_name' to set "
+                        "the required IDS name"
+                    )
+
+            ids_name = next(iter(ids_names))
     else:
-        vtpc_files = [path]
         if not ids_name:
             raise click.UsageError(
                 "Argument '--ids_name' is required for single file conversion."
             )
+        vtpc_files = [path]
+
+    if ids_name not in imas.IDSFactory().ids_names():
+        raise click.UsageError(f"{ids_name} is not a valid IDS name")
 
     click.echo(f"Converting {len(vtpc_files)} time steps for IDS '{ids_name}'...")
 
@@ -244,14 +254,6 @@ def convert_vtk_to_ggd(path, uri, ids_name, dd_version):
     ids = converter.convert()
 
     with imas.DBEntry(uri, "x", dd_version=dd_version) as entry:
-        # Set version_put properties (version_put was added in DD 3.22)
-        if hasattr(ids.ids_properties, "version_put"):
-            ids.ids_properties.version_put.access_layer = (
-                entry._dbe_impl.access_layer_version()
-            )
-            version_put = ids.ids_properties.version_put
-            version_put.data_dictionary = entry.dd_version
-            version_put.access_layer_language = f"IMAS-Python {imas.__version__}"
         entry.put(ids)
 
     click.echo(f"Successfully wrote {len(vtpc_files)} time steps to {uri}")

--- a/imas_paraview/cli.py
+++ b/imas_paraview/cli.py
@@ -236,7 +236,7 @@ def convert_vtk_to_ggd(path, uri, ids_name, dd_version):
                         "the required IDS name"
                     )
 
-            ids_name = next(iter(ids_names))
+            (ids_name,) = ids_names
     else:
         if not ids_name:
             raise click.UsageError(

--- a/imas_paraview/convert.py
+++ b/imas_paraview/convert.py
@@ -4,8 +4,7 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Optional
 
-import vtk
-from vtk import vtkXMLPartitionedDataSetCollectionWriter
+from vtk import vtkDataObject, vtkXMLPartitionedDataSetCollectionWriter
 from vtkmodules.vtkCommonCore import vtkPoints
 from vtkmodules.vtkCommonDataModel import (
     vtkCompositeDataSet,
@@ -67,7 +66,11 @@ class Converter:
             if vtk_object is None:
                 logger.warning("Could not convert GGD at time index %d to VTK.", index)
                 continue
-            self._write_vtk_to_xml(vtk_object, Path(f"{output_path}_{index}"), time)
+
+            # Store the time value of this slice in the vtk object
+            vtk_object.GetInformation().Set(vtkDataObject.DATA_TIME_STEP(), time)
+
+            self._write_vtk_to_xml(vtk_object, Path(f"{output_path}_{index}"))
 
     def ggd_to_vtk(
         self,
@@ -342,7 +345,7 @@ class Converter:
 
         self.output.GetMetaData(partition).Set(vtkCompositeDataSet.NAME(), label)
 
-    def _write_vtk_to_xml(self, vtk_object, output_path, time):
+    def _write_vtk_to_xml(self, vtk_object, output_path):
         """Writes a VTK object to XML file, and a directory containing files for each
         grid subset. The directory structure looks as follows:
         .
@@ -361,7 +364,6 @@ class Converter:
             logger.error("Cannot write None object to XML.")
             return
 
-        vtk_object.GetInformation().Set(vtk.vtkDataObject.DATA_TIME_STEP(), time)
         logger.info("Writing VTK file to '%s'...", output_path)
         writer = vtkXMLPartitionedDataSetCollectionWriter()
         writer.SetInputData(vtk_object)

--- a/imas_paraview/convert.py
+++ b/imas_paraview/convert.py
@@ -4,6 +4,7 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Optional
 
+import vtk
 from vtk import vtkXMLPartitionedDataSetCollectionWriter
 from vtkmodules.vtkCommonCore import vtkPoints
 from vtkmodules.vtkCommonDataModel import (
@@ -60,12 +61,13 @@ class Converter:
             raise RuntimeError("A provided index is out of bounds.")
 
         for index in index_list:
-            logger.info("Converting time step %f...", self.ids.time[index])
+            time = self.ids.time[index]
+            logger.info("Converting time step %f...", time)
             vtk_object = self.ggd_to_vtk(time_idx=index)
             if vtk_object is None:
                 logger.warning("Could not convert GGD at time index %d to VTK.", index)
                 continue
-            self._write_vtk_to_xml(vtk_object, Path(f"{output_path}_{index}"))
+            self._write_vtk_to_xml(vtk_object, Path(f"{output_path}_{index}"), time)
 
     def ggd_to_vtk(
         self,
@@ -340,7 +342,7 @@ class Converter:
 
         self.output.GetMetaData(partition).Set(vtkCompositeDataSet.NAME(), label)
 
-    def _write_vtk_to_xml(self, vtk_object, output_path):
+    def _write_vtk_to_xml(self, vtk_object, output_path, time):
         """Writes a VTK object to XML file, and a directory containing files for each
         grid subset. The directory structure looks as follows:
         .
@@ -359,6 +361,7 @@ class Converter:
             logger.error("Cannot write None object to XML.")
             return
 
+        vtk_object.GetInformation().Set(vtk.vtkDataObject.DATA_TIME_STEP(), time)
         logger.info("Writing VTK file to '%s'...", output_path)
         writer = vtkXMLPartitionedDataSetCollectionWriter()
         writer.SetInputData(vtk_object)

--- a/imas_paraview/io/read_geom.py
+++ b/imas_paraview/io/read_geom.py
@@ -5,8 +5,10 @@ children into distinct vtkUnstructuredGrid objects.
 """
 
 import logging
-from typing import Any, Callable
 
+import numpy as np
+from imas import identifiers
+from imas.ids_structure import IDSStructure
 from vtkmodules.vtkCommonCore import vtkIdList, vtkPoints
 from vtkmodules.vtkCommonDataModel import (
     VTK_EMPTY_CELL,
@@ -65,37 +67,60 @@ def fill_vtk_points(
     num_objects0d = len(grid_ggd.space[space_idx].objects_per_dimension[0].object)
     logger.info("Reading %d points from grid_ggd/space[%d]", num_objects0d, space_idx)
 
-    s = 1  # scale objects from mm to m
     if len(grid_ggd.space[space_idx].objects_per_dimension[0].object[0].geometry) == 0:
         raise RuntimeError("Geometry of object is empty.")
-    if grid_ggd.space[space_idx].objects_per_dimension[0].object[0].geometry[0] > 100:
-        s = 0.001
 
-    points.Allocate(num_objects0d, 0)
-    coordinate_type = grid_ggd.space[space_idx].coordinates_type
-
-    # When length of coordinate type is greater than 2, the third coordinate is in
-    # geometry[2], else it is 0.
-    if len(coordinate_type) > 2:
-        third_dim: Callable[[Any], int] = lambda e: getattr(e, "geometry")[2]  # noqa
+    coordinates_type = grid_ggd.space[space_idx].coordinates_type
+    # coordinates_type changed from INT_1D to an AoS of identifiers in DD4.0.0
+    if isinstance(coordinates_type[0], IDSStructure):
+        coord_indices = [int(ct.index) for ct in coordinates_type]
     else:
-        third_dim: Callable[[Any], int] = lambda e: 0  # noqa
+        coord_indices = [int(ct) for ct in coordinates_type]
+
+    coord_id = identifiers.coordinate_identifier
+    X, Y, Z = coord_id.x.value, coord_id.y.value, coord_id.z.value
+    R, PHI = coord_id.r.value, coord_id.phi.value
+
+    supported = {X, Y, Z, R, PHI}
+    unsupported = set(coord_indices) - supported
+    if unsupported:
+        logger.error(
+            "Unsupported coordinate types in '%s', space[%d]: %s. They will be ignored",
+            ids_name,
+            space_idx,
+            unsupported,
+        )
+
+    # Map coordinate identifier to position in geometry array
+    coord_pos = {coord_index: idx for idx, coord_index in enumerate(coord_indices)}
 
     objects = grid_ggd.space[space_idx].objects_per_dimension[0].object
+    points.Allocate(num_objects0d, 0)
     for obj in objects:
+        geom = obj.geometry
+
+        x = 0.0
+        y = 0.0
+        z = 0.0
+
+        if X in coord_pos:
+            x = geom[coord_pos[X]]
+        if Y in coord_pos:
+            y = geom[coord_pos[Y]]
+        if Z in coord_pos:
+            z = geom[coord_pos[Z]]
+
+        # Handle cylindrical coordinates
+        if R in coord_pos:
+            r = geom[coord_pos[R]]
+            phi = geom[coord_pos[PHI]] if PHI in coord_pos else 0.0
+            x = r * np.cos(phi)
+            y = r * np.sin(phi)
+
+        points.InsertNextPoint(x, y, z)
+
         if progress:
-            progress.increment(0.5 / len(objects))
-        if ids_name == "wall":
-            points.InsertNextPoint(
-                (obj.geometry[0] * s, obj.geometry[1] * s, third_dim(obj) * s)
-            )
-        else:
-            if len(obj.geometry) < 2:
-                raise RuntimeError("Geometry of object is smaller than 2.")
-            points.InsertNextPoint(
-                (obj.geometry[0] * s, third_dim(obj) * s, obj.geometry[1] * s)
-            )
-            # Use for changing orientation in paraview.
+            progress.increment(0.5 / num_objects0d)
 
 
 def _fill_vtk_cell_array_from_gs2(

--- a/imas_paraview/io/read_geom.py
+++ b/imas_paraview/io/read_geom.py
@@ -81,6 +81,24 @@ def fill_vtk_points(
     X, Y, Z = coord_id.x.value, coord_id.y.value, coord_id.z.value
     R, PHI = coord_id.r.value, coord_id.phi.value
 
+    # Old version of GGD Fortran library (<=1.12.0) did not set coordinate identifiers
+    # correctly, setting the points in r,phi-coordinates instead of r,z. For this case
+    # we overwrite the coordinate identifiers.
+    # This issue has been fixed in the following commit:
+    # https://github.com/iterorganization/GGD/commit/23af2f113e550fa6e8d05c982ddae53bf29c1cf1 # noqa: E501
+    if grid_ggd.space[
+        space_idx
+    ].geometry_type.description == "Poloidal plane cross-section" and coord_indices == [
+        R,
+        PHI,
+    ]:
+        logger.warning(
+            "The geometry type description was set to 'Poloidal plane cross-section' "
+            "but the coordinate identifiers were set to (r, phi). They have been "
+            "interpreted as (r, z) instead."
+        )
+        coord_indices = [R, Z]
+
     supported = {X, Y, Z, R, PHI}
     unsupported = set(coord_indices) - supported
     if unsupported:

--- a/imas_paraview/io/read_geom.py
+++ b/imas_paraview/io/read_geom.py
@@ -86,16 +86,13 @@ def fill_vtk_points(
     # we overwrite the coordinate identifiers.
     # This issue has been fixed in the following commit:
     # https://github.com/iterorganization/GGD/commit/23af2f113e550fa6e8d05c982ddae53bf29c1cf1 # noqa: E501
-    if grid_ggd.space[
-        space_idx
-    ].geometry_type.description == "Poloidal plane cross-section" and coord_indices == [
+    if grid_ggd.space[space_idx].geometry_type.name == "Poloidal" and coord_indices == [
         R,
         PHI,
     ]:
         logger.warning(
-            "The geometry type description was set to 'Poloidal plane cross-section' "
-            "but the coordinate identifiers were set to (r, phi). They have been "
-            "interpreted as (r, z) instead."
+            "The geometry type was set to 'Poloidal' but the coordinate identifiers "
+            "were set to (r, phi). They have been interpreted as (r, z) instead."
         )
         coord_indices = [R, Z]
 

--- a/imas_paraview/plugins/base_class.py
+++ b/imas_paraview/plugins/base_class.py
@@ -29,17 +29,11 @@ from imas_paraview.paraview_support.servermanager_tools import (
     stringlistdomain,
     stringvector,
 )
-from imas_paraview.util import get_grid_ggd
+from imas_paraview.util import get_grid_ggd, has_imas_core
 
 logger = logging.getLogger("imas_paraview")
 
-try:
-    has_imas = imas.backends.imas_core.imas_interface.has_imas
-except AttributeError:
-    # imas-python >= v2.2.0 always has IMAS-Core installed
-    has_imas = True
-
-if has_imas:
+if has_imas_core():
     BACKENDS = {
         "MDSplus": imas.ids_defs.MDSPLUS_BACKEND,
         "HDF5": imas.ids_defs.HDF5_BACKEND,

--- a/imas_paraview/plugins/base_class.py
+++ b/imas_paraview/plugins/base_class.py
@@ -33,7 +33,13 @@ from imas_paraview.util import get_grid_ggd
 
 logger = logging.getLogger("imas_paraview")
 
-if imas.backends.imas_core.imas_interface.has_imas:
+try:
+    has_imas = imas.backends.imas_core.imas_interface.has_imas
+except AttributeError:
+    # imas-python >= v2.2.0 always has IMAS-Core installed
+    has_imas = True
+
+if has_imas:
     BACKENDS = {
         "MDSplus": imas.ids_defs.MDSPLUS_BACKEND,
         "HDF5": imas.ids_defs.HDF5_BACKEND,

--- a/imas_paraview/tests/conftest.py
+++ b/imas_paraview/tests/conftest.py
@@ -65,7 +65,13 @@ def pytest_sessionstart(session):
     with imas.DBEntry("netcdf_testdb.nc", "w", dd_version=DD_VERSION) as dbentry:
         dbentry.put(ids)
 
-    if not imas.backends.imas_core.imas_interface.has_imas:
+    try:
+        has_imas = imas.backends.imas_core.imas_interface.has_imas
+    except AttributeError:
+        # imas-python >= v2.2.0 always has IMAS-Core installed
+        has_imas = True
+
+    if not has_imas:
         logger.warning(
             "IMAS-Core is not available, some integration tests are skipped."
         )

--- a/imas_paraview/tests/conftest.py
+++ b/imas_paraview/tests/conftest.py
@@ -8,7 +8,6 @@ import pytest
 
 from imas_paraview.plugins.vtkggdreader import SUPPORTED_IDS_NAMES
 from imas_paraview.tests.fill_ggd import fill_ids
-from imas_paraview.util import has_imas_core
 
 logger = logging.getLogger("imas_paraview")
 
@@ -65,12 +64,6 @@ def pytest_sessionstart(session):
     # Write test file as netCDF
     with imas.DBEntry("netcdf_testdb.nc", "w", dd_version=DD_VERSION) as dbentry:
         dbentry.put(ids)
-
-    if not has_imas_core():
-        logger.warning(
-            "IMAS-Core is not available, some integration tests are skipped."
-        )
-        return
 
     # Write integration test file as MDSPlus
     if not session.config.getoption("--skip-mdsplus"):

--- a/imas_paraview/tests/conftest.py
+++ b/imas_paraview/tests/conftest.py
@@ -8,6 +8,7 @@ import pytest
 
 from imas_paraview.plugins.vtkggdreader import SUPPORTED_IDS_NAMES
 from imas_paraview.tests.fill_ggd import fill_ids
+from imas_paraview.util import has_imas_core
 
 logger = logging.getLogger("imas_paraview")
 
@@ -65,13 +66,7 @@ def pytest_sessionstart(session):
     with imas.DBEntry("netcdf_testdb.nc", "w", dd_version=DD_VERSION) as dbentry:
         dbentry.put(ids)
 
-    try:
-        has_imas = imas.backends.imas_core.imas_interface.has_imas
-    except AttributeError:
-        # imas-python >= v2.2.0 always has IMAS-Core installed
-        has_imas = True
-
-    if not has_imas:
+    if not has_imas_core():
         logger.warning(
             "IMAS-Core is not available, some integration tests are skipped."
         )

--- a/imas_paraview/tests/fill_ggd.py
+++ b/imas_paraview/tests/fill_ggd.py
@@ -20,6 +20,8 @@ def fill_NxN_grid(grid_ggd, N, create_3d_grid=False):
     Args:
         grid_ggd: The GGD grid that will be filled with the N x N grid.
         N: The size of the N x N grid
+        create_3d_grid: If True, create a 2D grid in 3D space (in the X-Z plane at
+            Y = 0). If False, create a 2D grid in the X-Y plane.
 
     Returns:
         num_vertices: The number of vertices in the generated grid_ggd
@@ -36,10 +38,11 @@ def fill_NxN_grid(grid_ggd, N, create_3d_grid=False):
     space.identifier = identifiers.ggd_space_identifier.primary_standard
     space.geometry_type.index = 0  # standard, non-Fourier geometry
 
-    # Changed from INT_1D to AoS of identifiers in DD4.0.0
     num_dimension = 3 if create_3d_grid else 2
     space.coordinates_type.resize(num_dimension)
     coordinate_identifier = identifiers.coordinate_identifier
+
+    # coordinates_type changed from INT_1D to AoS of identifiers in DD4.0.0
     if isinstance(space.coordinates_type, IDSStructure):
         space.coordinates_type[0] = coordinate_identifier.x
         space.coordinates_type[1] = coordinate_identifier.y
@@ -83,7 +86,7 @@ def fill_NxN_grid(grid_ggd, N, create_3d_grid=False):
         element.object[0].dimension = 2
         element.object[0].index = i + 1
 
-    # Create elements for faces
+    # Create elements for cells
     grid_subsets[2].element.resize(num_faces)
     for i, element in enumerate(grid_subsets[2].element):
         element.object.resize(1)
@@ -100,6 +103,8 @@ def build_grid(N, space, create_3d_grid):
     Args:
         N: Size of the grid
         space: Space AoS of the GGD grid
+        create_3d_grid: If True, create a 2D grid in 3D space (in the X-Z plane at
+            Y = 0). If False, create a 2D grid in the X-Y plane.
 
     Returns:
         num_vertices: The total number of vertices
@@ -118,6 +123,8 @@ def set_vertices(N, space, create_3d_grid):
     Args:
         N: Size of the grid
         space: Space AoS of the GGD grid
+        create_3d_grid: If True, create a 2D grid in 3D space (in the X-Z plane at
+            Y = 0). If False, create a 2D grid in the X-Y plane.
 
     Returns:
         num_vertices: The total number of vertices
@@ -381,13 +388,20 @@ def fill_ids(
     create_3d_grid=False,
     dynamic_grid_size=False,
 ):
-    """Fills the IDS with an N x N uniform GGD grid and fills all GGD arrays on this
-    grid with random values.
+    """Fills the IDS with an N x N uniform GGD grid and optionally fills all GGD arrays
+    on this grid with random values.
 
     Args:
         ids: IDS to be filled.
         time_steps: Number of time steps to create in the IDS.
         grid_size: Size of the N x N grid. Defaults to 2, meaning a 2 x 2 grid.
+        fill_ggd: Whether to fill the GGD arrays on the grid. If set to False, only
+            the grid itself will be created.
+        create_3d_grid: If True, create a 2D grid in 3D space (in the X-Z plane at
+            Y = 0). If False, create a 2D grid in the X-Y plane.
+        dynamic_grid_size: If True, increase the grid size from `grid_size` by 1 for
+            each subsequent time step. E.g. if `grid_size = 2` and `time_step=3`, then
+            grids of sizes 2, 3 x 3, and 4 x 4 will be created.
     """
 
     # Create an empty grid_ggd
@@ -396,29 +410,31 @@ def fill_ids(
     # Skip filling grid_ggd if it does not exist
     if grid_ggd is None:
         logger.warning("%s has no grid_ggd", ids.metadata.name)
-    else:
-        # Create time steps
-        ids.time = [float(t) for t in range(time_steps)]
-        ids.ids_properties.homogeneous_time = imas.ids_defs.IDS_TIME_MODE_HOMOGENEOUS
+        return
 
-        # Create grid and GGD AoS
-        grid_ggd_aos = imas.util.get_parent(grid_ggd)
+    # Create time steps
+    ids.time = [float(t) for t in range(time_steps)]
+    ids.ids_properties.homogeneous_time = imas.ids_defs.IDS_TIME_MODE_HOMOGENEOUS
 
-        grid_ggd_aos.resize(time_steps)
+    # Create grid and GGD AoS
+    grid_ggd_aos = imas.util.get_parent(grid_ggd)
 
-        # Create uniform grids and fill them with random GGD data
-        for i in range(time_steps):
-            num_vertices, num_edges, num_faces = fill_NxN_grid(
-                grid_ggd_aos[i], grid_size, create_3d_grid=create_3d_grid
-            )
-            if dynamic_grid_size:
-                grid_size += 1
-            logger.debug("filled grid_ggd at index %d.", i)
-        if fill_ggd:
-            ggd = create_first_ggd(ids)
-            ggd_aos = imas.util.get_parent(ggd)
-            ggd_aos.resize(time_steps)
-            fill_ggd_data(ids, num_vertices, num_edges, num_faces)
+    grid_ggd_aos.resize(time_steps)
+
+    # Create uniform grids for each time step
+    for i in range(time_steps):
+        num_vertices, num_edges, num_faces = fill_NxN_grid(
+            grid_ggd_aos[i], grid_size, create_3d_grid=create_3d_grid
+        )
+        if dynamic_grid_size:
+            grid_size += 1
+        logger.debug("filled grid_ggd at index %d.", i)
+
+    if fill_ggd:
+        ggd = create_first_ggd(ids)
+        ggd_aos = imas.util.get_parent(ggd)
+        ggd_aos.resize(time_steps)
+        fill_ggd_data(ids, num_vertices, num_edges, num_faces)
 
     fill_ids_specific(ids)
 

--- a/imas_paraview/tests/fill_ggd.py
+++ b/imas_paraview/tests/fill_ggd.py
@@ -409,7 +409,7 @@ def fill_ids(
         # Create uniform grids and fill them with random GGD data
         for i in range(time_steps):
             num_vertices, num_edges, num_faces = fill_NxN_grid(
-                grid_ggd_aos[i], grid_size, create_3d_grid
+                grid_ggd_aos[i], grid_size, create_3d_grid=create_3d_grid
             )
             if dynamic_grid_size:
                 grid_size += 1

--- a/imas_paraview/tests/fill_ggd.py
+++ b/imas_paraview/tests/fill_ggd.py
@@ -2,6 +2,8 @@ import logging
 
 import imas
 import numpy as np
+from imas import identifiers
+from imas.ids_structure import IDSStructure
 
 from imas_paraview.ids_util import get_arrays_from_ids
 from imas_paraview.util import create_first_ggd, create_first_grid, int32array
@@ -9,7 +11,7 @@ from imas_paraview.util import create_first_ggd, create_first_grid, int32array
 logger = logging.getLogger("imas_paraview")
 
 
-def fill_NxN_grid(grid_ggd, N):
+def fill_NxN_grid(grid_ggd, N, create_3d_grid=False):
     """Fills the grid_ggd of an IDS with a uniform rectangular grid of size N x N,
     containing vertices, edges and faces.
 
@@ -26,43 +28,46 @@ def fill_NxN_grid(grid_ggd, N):
     """
 
     # Set grid
-    grid_ggd.identifier.name = "linear"
-    grid_ggd.identifier.index = 1
-    grid_ggd.identifier.description = f"A simple {N} x {N} rectangular grid"
+    grid_ggd.identifier = identifiers.ggd_identifier.linear
 
     # Set space
     grid_ggd.space.resize(1)
     space = grid_ggd.space[0]
-    space.identifier.name = "primary_standard"
-    space.identifier.index = 1
-    space.identifier.description = "Primary space defining the standard grid"
-    space.geometry_type.index = 0
-    space.coordinates_type.resize(2)
-    space.coordinates_type[0] = 1
-    space.coordinates_type[1] = 2
+    space.identifier = identifiers.ggd_space_identifier.primary_standard
+    space.geometry_type.index = 0  # standard, non-Fourier geometry
+
+    # Changed from INT_1D to AoS of identifiers in DD4.0.0
+    num_dimension = 3 if create_3d_grid else 2
+    space.coordinates_type.resize(num_dimension)
+    coordinate_identifier = identifiers.coordinate_identifier
+    if isinstance(space.coordinates_type, IDSStructure):
+        space.coordinates_type[0] = coordinate_identifier.x
+        space.coordinates_type[1] = coordinate_identifier.y
+        if create_3d_grid:
+            space.coordinates_type[2] = coordinate_identifier.z
+    else:
+        space.coordinates_type[0] = coordinate_identifier.x.index
+        space.coordinates_type[1] = coordinate_identifier.y.index
+        if create_3d_grid:
+            space.coordinates_type[2] = coordinate_identifier.z.index
 
     space.objects_per_dimension.resize(3)
-    num_vertices, num_edges, num_faces = build_grid(N, space)
+    num_vertices, num_edges, num_faces = build_grid(N, space, create_3d_grid)
 
     # Create subset
     grid_ggd.grid_subset.resize(3)
+    ggd_subset_identifier = identifiers.ggd_subset_identifier
     grid_subsets = grid_ggd.grid_subset
     grid_subsets[0].dimension = 1
-    grid_subsets[0].identifier.name = "vertices"
-    grid_subsets[0].identifier.index = 1
-    grid_subsets[0].identifier.description = "All vertices in the domain"
+    grid_subsets[0].identifier = ggd_subset_identifier.nodes
 
     grid_subsets[1].dimension = 2
-    grid_subsets[1].identifier.name = "edges"
-    grid_subsets[1].identifier.index = 2
-    grid_subsets[1].identifier.description = "All edges in the domain"
+    grid_subsets[1].identifier = ggd_subset_identifier.edges
 
     grid_subsets[2].dimension = 3
-    grid_subsets[2].identifier.name = "faces"
-    grid_subsets[2].identifier.index = 5
-    grid_subsets[2].identifier.description = "All faces in the domain"
+    grid_subsets[2].identifier = ggd_subset_identifier.cells
 
-    # Create elements for vertices
+    # Create elements for nodes
     grid_subsets[0].element.resize(num_vertices)
     for i, element in enumerate(grid_subsets[0].element):
         element.object.resize(1)
@@ -89,7 +94,7 @@ def fill_NxN_grid(grid_ggd, N):
     return num_vertices, num_edges, num_faces
 
 
-def build_grid(N, space):
+def build_grid(N, space, create_3d_grid):
     """Builds the vertices, edges and faces for an N x N grid.
 
     Args:
@@ -101,13 +106,13 @@ def build_grid(N, space):
         num_edges: The total number of edges
         num_faces: The total number of faces
     """
-    num_vertices = set_vertices(N, space)
+    num_vertices = set_vertices(N, space, create_3d_grid)
     num_edges = set_edges(N, space)
     num_faces = set_faces(N, space)
     return num_vertices, num_edges, num_faces
 
 
-def set_vertices(N, space):
+def set_vertices(N, space, create_3d_grid):
     """Sets the vertices for an N x N grid.
 
     Args:
@@ -125,7 +130,10 @@ def set_vertices(N, space):
     for i in range(N):
         for j in range(N):
             idx = i * N + j
-            vertices[idx].geometry = [float(j), float(i)]
+            if create_3d_grid:
+                vertices[idx].geometry = [float(j), 0.0, float(i)]
+            else:
+                vertices[idx].geometry = [float(j), float(i)]
     return num_vertices
 
 
@@ -365,7 +373,14 @@ def fill_ggd_data(ids, num_vertices, num_edges, num_faces):
             fill_vector_rzphi_quantity(vector_array, num_vertices, num_edges, num_faces)
 
 
-def fill_ids(ids, time_steps=1, grid_size=2):
+def fill_ids(
+    ids,
+    time_steps=1,
+    grid_size=2,
+    fill_ggd=True,
+    create_3d_grid=False,
+    dynamic_grid_size=False,
+):
     """Fills the IDS with an N x N uniform GGD grid and fills all GGD arrays on this
     grid with random values.
 
@@ -390,17 +405,20 @@ def fill_ids(ids, time_steps=1, grid_size=2):
         grid_ggd_aos = imas.util.get_parent(grid_ggd)
 
         grid_ggd_aos.resize(time_steps)
-        ggd = create_first_ggd(ids)
-        ggd_aos = imas.util.get_parent(ggd)
-        ggd_aos.resize(time_steps)
 
         # Create uniform grids and fill them with random GGD data
         for i in range(time_steps):
             num_vertices, num_edges, num_faces = fill_NxN_grid(
-                grid_ggd_aos[i], grid_size
+                grid_ggd_aos[i], grid_size, create_3d_grid
             )
+            if dynamic_grid_size:
+                grid_size += 1
             logger.debug("filled grid_ggd at index %d.", i)
-        fill_ggd_data(ids, num_vertices, num_edges, num_faces)
+        if fill_ggd:
+            ggd = create_first_ggd(ids)
+            ggd_aos = imas.util.get_parent(ggd)
+            ggd_aos.resize(time_steps)
+            fill_ggd_data(ids, num_vertices, num_edges, num_faces)
 
     fill_ids_specific(ids)
 

--- a/imas_paraview/tests/fill_ggd.py
+++ b/imas_paraview/tests/fill_ggd.py
@@ -138,9 +138,9 @@ def set_vertices(N, space, create_3d_grid):
         for j in range(N):
             idx = i * N + j
             if create_3d_grid:
-                vertices[idx].geometry = [float(j), 0.0, float(i)]
+                vertices[idx].geometry = [0.5 * float(j), 0.0, float(i)]
             else:
-                vertices[idx].geometry = [float(j), float(i)]
+                vertices[idx].geometry = [0.5 * float(j), float(i)]
     return num_vertices
 
 

--- a/imas_paraview/tests/test_cli.py
+++ b/imas_paraview/tests/test_cli.py
@@ -8,10 +8,12 @@ from conftest import DD_VERSION
 from imas_paraview.cli import (
     cli,
     convert_ggd_to_vtk,
+    convert_vtk_to_ggd,
     parse_index,
     parse_time,
     parse_uri,
 )
+from imas_paraview.tests.fill_ggd import fill_ids
 
 
 @pytest.mark.skip(reason="no IMAS-Core available")
@@ -64,6 +66,41 @@ def test_ggd2vtk(tmp_path, dummy_ids):
         for i in range(3):
             vtu_file = output_dir / f"{ids_name}_0_{i}_0.vtu"
             assert vtu_file.exists()
+
+
+def test_vtk2ggd(tmp_path):
+    # Create original IDS
+    ids_name = "edge_profiles"
+    uri = f"{tmp_path}/testdb.nc"
+    ids = imas.IDSFactory(version=DD_VERSION).new(ids_name)
+    fill_ids(
+        ids, time_steps=5, fill_ggd=False, create_3d_grid=True, dynamic_grid_size=True
+    )
+    with imas.DBEntry(uri, "w", dd_version=DD_VERSION) as dbentry:
+        dbentry.put(ids)
+
+    # Convert IDS to VTK
+    runner = CliRunner()
+    file_name = "vtk_data"
+    output_path = tmp_path / file_name
+    uri_in = f"{uri}#{ids_name}"
+    args = [uri_in, str(output_path), "--all-times"]
+    result = runner.invoke(convert_ggd_to_vtk, args)
+    assert result.exit_code == 0
+
+    # Convert VTK back to IDS
+    uri_out = f"{tmp_path}/back_converted.nc"
+    args = [str(output_path), uri_out, "--dd_version", DD_VERSION]
+    result = runner.invoke(convert_vtk_to_ggd, args)
+    assert result.exit_code == 0
+
+    with imas.DBEntry(uri_out, "r", dd_version=DD_VERSION) as dbentry:
+        ids2 = dbentry.get(ids_name)
+
+    # Work-around to test equivalence of two IDSs
+    # During reading/writing to disk identifiers index converted from int to np.int32,
+    # which do not support calling imas.util.calc_hash()
+    assert not list(imas.util.idsdiffgen(ids, ids2))
 
 
 def test_parse_uri():

--- a/imas_paraview/tests/test_cli.py
+++ b/imas_paraview/tests/test_cli.py
@@ -97,10 +97,8 @@ def test_vtk2ggd(tmp_path):
     with imas.DBEntry(uri_out, "r", dd_version=DD_VERSION) as dbentry:
         ids2 = dbentry.get(ids_name)
 
-    # Work-around to test equivalence of two IDSs
-    # During reading/writing to disk identifiers index converted from int to np.int32,
-    # which do not support calling imas.util.calc_hash()
-    assert not list(imas.util.idsdiffgen(ids, ids2))
+    # Check if the two IDSs are the same
+    assert list(imas.util.idsdiffgen(ids, ids2)) == []
 
 
 def test_parse_uri():

--- a/imas_paraview/tests/test_cli.py
+++ b/imas_paraview/tests/test_cli.py
@@ -4,6 +4,9 @@ import pytest
 from click import UsageError
 from click.testing import CliRunner
 from conftest import DD_VERSION
+from vtkmodules.vtkCommonCore import vtkPoints
+from vtkmodules.vtkCommonDataModel import vtkQuad, vtkUnstructuredGrid
+from vtkmodules.vtkIOXML import vtkXMLUnstructuredGridWriter
 
 from imas_paraview.cli import (
     cli,
@@ -99,6 +102,55 @@ def test_vtk2ggd(tmp_path):
 
     # Check if the two IDSs are the same
     assert list(imas.util.idsdiffgen(ids, ids2)) == []
+
+
+def test_vtk2ggd_unstructured_grid(tmp_path):
+    # Build a simple square vtkUnstructuredGrid
+    points = vtkPoints()
+    points.InsertNextPoint(0.0, 0.0, 0.0)
+    points.InsertNextPoint(1.0, 0.0, 0.0)
+    points.InsertNextPoint(1.0, 1.0, 0.0)
+    points.InsertNextPoint(0.0, 1.0, 0.0)
+
+    quad = vtkQuad()
+    quad.GetPointIds().SetId(0, 0)
+    quad.GetPointIds().SetId(1, 1)
+    quad.GetPointIds().SetId(2, 2)
+    quad.GetPointIds().SetId(3, 3)
+
+    ugrid = vtkUnstructuredGrid()
+    ugrid.SetPoints(points)
+    ugrid.InsertNextCell(quad.GetCellType(), quad.GetPointIds())
+
+    # Write to .vtu file
+    vtu_path = tmp_path / "test_grid.vtu"
+    writer = vtkXMLUnstructuredGridWriter()
+    writer.SetFileName(str(vtu_path))
+    writer.SetInputData(ugrid)
+    writer.Write()
+
+    # Convert .vtu to IDS
+    ids_name = "edge_profiles"
+    uri_out = f"{tmp_path}/output.nc"
+    runner = CliRunner()
+    args = [str(vtu_path), uri_out, "--ids_name", ids_name, "--dd_version", DD_VERSION]
+    result = runner.invoke(convert_vtk_to_ggd, args)
+    assert result.exit_code == 0
+
+    with imas.DBEntry(uri_out, "r", dd_version=DD_VERSION) as dbentry:
+        ids2 = dbentry.get(ids_name)
+    assert len(ids2.time) == 1
+    space = ids2.grid_ggd[0].space[0]
+    assert len(space.objects_per_dimension[0].object) == 4
+    node_coords = [list(obj.geometry) for obj in space.objects_per_dimension[0].object]
+    assert node_coords == [
+        [0.0, 0.0, 0.0],
+        [1.0, 0.0, 0.0],
+        [1.0, 1.0, 0.0],
+        [0.0, 1.0, 0.0],
+    ]
+    assert len(space.objects_per_dimension[2].object) == 1  # 1 quad cell
+    assert list(space.objects_per_dimension[2].object[0].nodes) == [1, 2, 3, 4]
 
 
 def test_parse_uri():

--- a/imas_paraview/tests/test_fill_ggd.py
+++ b/imas_paraview/tests/test_fill_ggd.py
@@ -1,5 +1,40 @@
+import imas
+import numpy as np
+
+from imas_paraview.tests.fill_ggd import fill_ids
+
+
 def test_validate_dummy_ids(dummy_ids):
     """Validates the dummy IDS object created by the fixture."""
 
     ids = dummy_ids
     ids.validate()
+
+
+def test_fill_ggd():
+    ids_name = "edge_profiles"
+    dd_version = "4.0.0"
+    ids = imas.IDSFactory(version=dd_version).new(ids_name)
+    fill_ids(ids)
+
+    space = ids.grid_ggd[0].space[0]
+
+    expected_vertices = [
+        [0.0, 0.0],
+        [0.5, 0.0],
+        [0.0, 1.0],
+        [0.5, 1.0],
+    ]
+    for i, expected in enumerate(expected_vertices):
+        assert np.allclose(space.objects_per_dimension[0].object[i].geometry, expected)
+
+    expected_edges = [
+        [1, 2],
+        [3, 4],
+        [1, 3],
+        [2, 4],
+    ]
+    for i, expected in enumerate(expected_edges):
+        assert np.array_equal(space.objects_per_dimension[1].object[i].nodes, expected)
+
+    assert np.array_equal(space.objects_per_dimension[2].object[0].nodes, [1, 2, 4, 3])

--- a/imas_paraview/tests/test_vtk2ggd.py
+++ b/imas_paraview/tests/test_vtk2ggd.py
@@ -1,0 +1,18 @@
+import imas
+
+from imas_paraview.convert import Converter
+from imas_paraview.tests.fill_ggd import fill_ids
+from imas_paraview.vtk2ggd import VTK2GGDConverter
+
+
+def test_round_trip():
+    ids_name = "edge_profiles"
+    dd_version = "4.0.0"
+    ids = imas.IDSFactory(version=dd_version).new(ids_name)
+    fill_ids(ids, fill_ggd=False, create_3d_grid=True)
+    converter = Converter(ids)
+    vtk_pdsc = converter.ggd_to_vtk()  # get Partitioned Dataset Collection
+    converter2 = VTK2GGDConverter([vtk_pdsc], ids_name, dd_version)
+    ids2 = converter2.convert()
+    # Check if grids are the same
+    assert imas.util.calc_hash(ids.grid_ggd) == imas.util.calc_hash(ids2.grid_ggd)

--- a/imas_paraview/tests/test_vtk2ggd.py
+++ b/imas_paraview/tests/test_vtk2ggd.py
@@ -10,9 +10,14 @@ def test_round_trip():
     dd_version = "4.0.0"
     ids = imas.IDSFactory(version=dd_version).new(ids_name)
     fill_ids(ids, fill_ggd=False, create_3d_grid=True)
+
+    # Convert IDS to VTK
     converter = Converter(ids)
-    vtk_pdsc = converter.ggd_to_vtk()  # get Partitioned Dataset Collection
-    converter2 = VTK2GGDConverter([vtk_pdsc], ids_name, dd_version)
+    vtk_pdsc = converter.ggd_to_vtk()
+
+    # Convert VTK back to IDS
+    converter2 = VTK2GGDConverter([vtk_pdsc], ids_name, dd_version=dd_version)
     ids2 = converter2.convert()
-    # Check if grids are the same
-    assert imas.util.calc_hash(ids.grid_ggd) == imas.util.calc_hash(ids2.grid_ggd)
+
+    # Check if the two IDSs are the same
+    assert list(imas.util.idsdiffgen(ids, ids2)) == []

--- a/imas_paraview/util.py
+++ b/imas_paraview/util.py
@@ -204,6 +204,21 @@ def pol_to_cart(rho, phi):
     return (x, y)
 
 
+def cart_to_pol(x, y):
+    """Convert from cartesian to polar coordinates.
+
+    Args:
+        x: the distance in the x-direction
+        y: the distance in the y-direction
+
+    Returns:
+        Tuple containing the r and phi coordinates
+    """
+    r = np.sqrt(x**2 + y**2)
+    phi = np.arctan2(y, x)
+    return (r, phi)
+
+
 def points_to_vtkpoly(points, is_closed=False, is_filled=False):
     """Convert a list of 3D points to a vtkPoints and vtkCellArray, which are combined
     into a single VtkPolyData object. The expected format of the points is:

--- a/imas_paraview/util.py
+++ b/imas_paraview/util.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Optional
 
+import imas
 import numpy as np
 from vtk import vtkDataObject, vtkStreamingDemandDrivenPipeline
 from vtkmodules.util.numpy_support import numpy_to_vtk, vtk_to_numpy
@@ -269,6 +270,12 @@ def load_vtpc(file_path):
         if time_steps:
             # NOTE: IMAS-ParaView exports only a single time step per
             # vtkPartitionedDataSetCollection
+            if len(time_steps) > 1:
+                logger.warning(
+                    "The partitioned dataset collection at '%s' contains multiple time "
+                    "steps. Only the first time step will be converted!",
+                    file_path,
+                )
             time_value = time_steps[0]
 
     reader.Update()
@@ -288,3 +295,12 @@ def vtk_cells_to_nodes(cell_array):
     return [  # GGD uses 1-based indexing
         connectivity[offsets[i] : offsets[i + 1]] + 1 for i in range(len(offsets) - 1)
     ]
+
+
+def has_imas_core():
+    """Check whether imas-core is available."""
+    try:
+        return imas.backends.imas_core.imas_interface.has_imas
+    except AttributeError:
+        # imas-python >= v2.2.0 always has IMAS-Core installed
+        return True

--- a/imas_paraview/util.py
+++ b/imas_paraview/util.py
@@ -2,7 +2,7 @@ import logging
 from typing import Optional
 
 import numpy as np
-import vtk
+from vtk import vtkDataObject, vtkStreamingDemandDrivenPipeline
 from vtkmodules.util.numpy_support import numpy_to_vtk, vtk_to_numpy
 from vtkmodules.vtkCommonCore import vtkPoints
 from vtkmodules.vtkCommonDataModel import vtkCellArray, vtkPolyData
@@ -253,35 +253,38 @@ def points_to_vtkpoly(points, is_closed=False, is_filled=False):
 
 
 def load_vtpc(file_path):
-    """
-    Enhanced loader that ensures time metadata is migrated
-    from the reader to the data object.
+    """Load a vtkPartitionedDataSetCollection from disk.
+
+    Args:
+        file_path: The file path to the vtkPartitionedDataSetCollection.
     """
     reader = vtkXMLPartitionedDataSetCollectionReader()
     reader.SetFileName(str(file_path))
     reader.UpdateInformation()
     out_info = reader.GetOutputInformation(0)
-    has_time = out_info.Has(vtk.vtkStreamingDemandDrivenPipeline.TIME_STEPS())
 
     time_value = None
-    if has_time:
-        time_steps = out_info.Get(vtk.vtkStreamingDemandDrivenPipeline.TIME_STEPS())
+    if out_info.Has(vtkStreamingDemandDrivenPipeline.TIME_STEPS()):
+        time_steps = out_info.Get(vtkStreamingDemandDrivenPipeline.TIME_STEPS())
         if time_steps:
+            # NOTE: IMAS-ParaView exports only a single time step per
+            # vtkPartitionedDataSetCollection
             time_value = time_steps[0]
 
     reader.Update()
     vtk_obj = reader.GetOutput()
 
+    # Store time step as vtkDataObject
     if time_value is not None:
-        vtk_obj.GetInformation().Set(vtk.vtkDataObject.DATA_TIME_STEP(), time_value)
-
+        vtk_obj.GetInformation().Set(vtkDataObject.DATA_TIME_STEP(), time_value)
     return vtk_obj
 
 
 def vtk_cells_to_nodes(cell_array):
+    """Convert a VTK cell array into a list of node index (1-based) arrays."""
     offsets = vtk_to_numpy(cell_array.GetOffsetsArray())
     connectivity = vtk_to_numpy(cell_array.GetConnectivityArray())
 
-    return [  # 1-based indexing
+    return [  # GGD uses 1-based indexing
         connectivity[offsets[i] : offsets[i + 1]] + 1 for i in range(len(offsets) - 1)
     ]

--- a/imas_paraview/util.py
+++ b/imas_paraview/util.py
@@ -6,8 +6,16 @@ import numpy as np
 from vtk import vtkDataObject, vtkStreamingDemandDrivenPipeline
 from vtkmodules.util.numpy_support import numpy_to_vtk, vtk_to_numpy
 from vtkmodules.vtkCommonCore import vtkPoints
-from vtkmodules.vtkCommonDataModel import vtkCellArray, vtkPolyData
-from vtkmodules.vtkIOXML import vtkXMLPartitionedDataSetCollectionReader
+from vtkmodules.vtkCommonDataModel import (
+    vtkCellArray,
+    vtkPartitionedDataSet,
+    vtkPartitionedDataSetCollection,
+    vtkPolyData,
+)
+from vtkmodules.vtkIOXML import (
+    vtkXMLPartitionedDataSetCollectionReader,
+    vtkXMLUnstructuredGridReader,
+)
 
 logger = logging.getLogger("imas_paraview")
 
@@ -300,6 +308,33 @@ def load_vtpc(file_path):
     if time_value is not None:
         vtk_obj.GetInformation().Set(vtkDataObject.DATA_TIME_STEP(), time_value)
     return vtk_obj
+
+
+def load_vtu(file_path):
+    """Load a vtkUnstructuredGrid from a .vtu file and wrap it in a
+    vtkPartitionedDataSetCollection so it is compatible with VTK2GGDConverter.
+
+    Args:
+        file_path: The file path to the .vtu file.
+
+    Returns:
+        A vtkPartitionedDataSetCollection containing the unstructured grid.
+    """
+    reader = vtkXMLUnstructuredGridReader()
+    reader.SetFileName(str(file_path))
+    reader.Update()
+    ugrid = reader.GetOutput()
+
+    pds = vtkPartitionedDataSet()
+    pds.SetNumberOfPartitions(1)
+    pds.SetPartition(0, ugrid)
+
+    vtpc = vtkPartitionedDataSetCollection()
+    vtpc.SetNumberOfPartitionedDataSets(1)
+    vtpc.SetPartitionedDataSet(0, pds)
+
+    vtpc.GetMetaData(0).Set(vtpc.NAME(), file_path.stem)
+    return vtpc
 
 
 def vtk_cells_to_nodes(cell_array):

--- a/imas_paraview/util.py
+++ b/imas_paraview/util.py
@@ -2,9 +2,11 @@ import logging
 from typing import Optional
 
 import numpy as np
-from vtkmodules.util.numpy_support import numpy_to_vtk
+import vtk
+from vtkmodules.util.numpy_support import numpy_to_vtk, vtk_to_numpy
 from vtkmodules.vtkCommonCore import vtkPoints
 from vtkmodules.vtkCommonDataModel import vtkCellArray, vtkPolyData
+from vtkmodules.vtkIOXML import vtkXMLPartitionedDataSetCollectionReader
 
 logger = logging.getLogger("imas_paraview")
 
@@ -248,3 +250,38 @@ def points_to_vtkpoly(points, is_closed=False, is_filled=False):
         poly.SetLines(lines)
 
     return poly
+
+
+def load_vtpc(file_path):
+    """
+    Enhanced loader that ensures time metadata is migrated
+    from the reader to the data object.
+    """
+    reader = vtkXMLPartitionedDataSetCollectionReader()
+    reader.SetFileName(str(file_path))
+    reader.UpdateInformation()
+    out_info = reader.GetOutputInformation(0)
+    has_time = out_info.Has(vtk.vtkStreamingDemandDrivenPipeline.TIME_STEPS())
+
+    time_value = None
+    if has_time:
+        time_steps = out_info.Get(vtk.vtkStreamingDemandDrivenPipeline.TIME_STEPS())
+        if time_steps:
+            time_value = time_steps[0]
+
+    reader.Update()
+    vtk_obj = reader.GetOutput()
+
+    if time_value is not None:
+        vtk_obj.GetInformation().Set(vtk.vtkDataObject.DATA_TIME_STEP(), time_value)
+
+    return vtk_obj
+
+
+def vtk_cells_to_nodes(cell_array):
+    offsets = vtk_to_numpy(cell_array.GetOffsetsArray())
+    connectivity = vtk_to_numpy(cell_array.GetConnectivityArray())
+
+    return [  # 1-based indexing
+        connectivity[offsets[i] : offsets[i + 1]] + 1 for i in range(len(offsets) - 1)
+    ]

--- a/imas_paraview/vtk2ggd.py
+++ b/imas_paraview/vtk2ggd.py
@@ -1,0 +1,208 @@
+import logging
+
+import imas
+import numpy as np
+import vtk
+from imas import identifiers
+from imas.ids_structure import IDSStructure
+from vtkmodules.util.numpy_support import vtk_to_numpy
+from vtkmodules.vtkCommonDataModel import (
+    vtkPartitionedDataSetCollection,
+    vtkUnstructuredGrid,
+)
+
+from imas_paraview.util import create_first_grid, int32array, vtk_cells_to_nodes
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+class VTK2GGDConverter:
+    """
+    Handles the back-conversion of multiple VTK objects into a single
+    IMAS GGD structure with multiple time steps.
+    """
+
+    def __init__(
+        self,
+        vtk_objects: list[vtkPartitionedDataSetCollection],
+        ids_name,
+        dd_version=None,
+    ):
+        self.ids_name = ids_name
+        self.factory = imas.IDSFactory(version=dd_version)
+        self.dd_version = self.factory.version
+        self.vtk_objects = vtk_objects
+
+    def convert(self):
+        ids, grid_ggd = self._setup_ids()
+
+        # Each partitioned dataset collection in the list contains the grid for a
+        # single time step
+        for time_idx, vtk_pdsc in enumerate(self.vtk_objects):
+            # TODO: Only support linear grids
+            grid_ggd[time_idx].identifier = identifiers.ggd_identifier.linear
+
+            self._set_time_step(ids, time_idx, vtk_pdsc)
+            space = self._setup_space(grid_ggd[time_idx], vtk_pdsc)
+
+            self._fill_space(space, vtk_pdsc)
+            self._build_grid_subsets(grid_ggd[time_idx], vtk_pdsc)
+
+        return ids
+
+    def _setup_ids(self):
+        ids = self.factory.new(self.ids_name)
+        first_grid = create_first_grid(ids)
+        if not first_grid:
+            raise RuntimeError(f"IDS '{self.ids_name}' does not have a GGD grid.")
+        grid_ggd = imas.util.get_parent(first_grid)
+
+        num_steps = len(self.vtk_objects)
+        ids.time = np.zeros(num_steps)
+        grid_ggd.resize(num_steps)
+
+        # TODO: only support HOMOGENEOUS TIME for now
+        ids.ids_properties.homogeneous_time = imas.ids_defs.IDS_TIME_MODE_HOMOGENEOUS
+
+        # Set version_put properties (version_put was added in DD 3.22)
+        if hasattr(ids.ids_properties, "version_put"):
+            version_put = ids.ids_properties.version_put
+            version_put.data_dictionary = self.dd_version
+            version_put.access_layer_language = f"IMAS-Python {imas.__version__}"
+        return ids, grid_ggd
+
+    def _set_time_step(self, ids, time_idx, vtk_pdsc):
+        info = vtk_pdsc.GetInformation()
+        if info.Has(vtk.vtkDataObject.DATA_TIME_STEP()):
+            time = info.Get(vtk.vtkDataObject.DATA_TIME_STEP())
+            ids.time[time_idx] = time
+            logger.info("Converting time step %d: t = %f", time_idx, time)
+        else:
+            logger.warning(
+                "The vtkPartitionedDataSetCollection at time index %d does not have a "
+                "time value. Using index as the time value instead.",
+                time_idx,
+            )
+            ids.time[time_idx] = time_idx
+
+    def read_vtk(self, vtk_pdsc):
+        points = None
+        objects_by_dimension = {}
+
+        for i in range(vtk_pdsc.GetNumberOfPartitionedDataSets()):
+            partitioned_dataset = vtk_pdsc.GetPartitionedDataSet(i)
+            # GGD2VTK only fills first partition of a partitioned dataset
+            ugrid = partitioned_dataset.GetPartition(0)
+            if ugrid is None or not isinstance(ugrid, vtkUnstructuredGrid):
+                logger.warning("partition %d does not contain an unstructured grid", i)
+                continue
+            if points is None and ugrid.GetNumberOfPoints() > 0:
+                points = vtk_to_numpy(ugrid.GetPoints().GetData()).astype(np.float64)
+            if ugrid.GetNumberOfCells() > 0:
+                dim = ugrid.GetCell(0).GetCellDimension()
+                if dim > 0:
+                    objects_by_dimension.setdefault(dim, []).extend(
+                        vtk_cells_to_nodes(ugrid.GetCells())
+                    )
+        return points, objects_by_dimension
+
+    def _fill_space(self, space, vtk_pdsc):
+        points, objects_by_dimension = self.read_vtk(vtk_pdsc)
+        # Fill nodes
+        if points is not None:
+            space.objects_per_dimension[0].object.resize(len(points))
+            for i, p in enumerate(points):
+                obj = space.objects_per_dimension[0].object[i]
+                obj.geometry.resize(3)
+                # Wall converts coordinates differently from other IDSs
+                if self.ids_name == "wall":
+                    obj.geometry[:] = [p[0], p[1], p[2]]
+                else:
+                    obj.geometry[:] = [p[0], p[2], p[1]]
+
+        # Fill cells
+        for dim, cells in objects_by_dimension.items():
+            space.objects_per_dimension[dim].object.resize(len(cells))
+            for i, nodes in enumerate(cells):
+                obj = space.objects_per_dimension[dim].object[i]
+                obj.nodes = int32array(nodes)
+
+    def _setup_space(self, grid_ggd, vtk_pdsc):
+        # TODO: Only support creating a single space, I think multiple spaces are
+        # lost upon conversion
+        grid_ggd.space.resize(1)
+        space = grid_ggd.space[0]
+        # NOTE: Only support primary standard spaces
+        space.identifier = identifiers.ggd_space_identifier.primary_standard
+        # NOTE: Only support non-fourier grids
+        space.geometry_type.index = 0
+        # coordinates_type changed from INT_1D to an AoS of identifiers in DD4.0.0
+        space.coordinates_type.resize(3)
+        # NOTE: Only support X,Y,Z coordinates
+        coord = identifiers.coordinate_identifier
+        for i, c in enumerate([coord.x, coord.y, coord.z]):
+            if isinstance(space.coordinates_type, IDSStructure):
+                space.coordinates_type[i] = c
+            else:
+                space.coordinates_type[i] = c.index
+        max_dim = self._get_max_dimension(vtk_pdsc)
+        space.objects_per_dimension.resize(max_dim + 1)
+        return space
+
+    def _get_max_dimension(self, vtk_pdsc):
+        max_dimension = 0
+        for i in range(vtk_pdsc.GetNumberOfPartitionedDataSets()):
+            pds = vtk_pdsc.GetPartitionedDataSet(i)
+            ug = pds.GetPartition(0) if pds.GetNumberOfPartitions() > 0 else None
+            if ug and ug.GetNumberOfCells() > 0:
+                max_dimension = max(max_dimension, ug.GetCell(0).GetCellDimension())
+        return max_dimension
+
+    def _build_grid_subsets(self, grid_ggd, vtk_pdsc):
+        num_partitions = vtk_pdsc.GetNumberOfPartitionedDataSets()
+        grid_ggd.grid_subset.resize(num_partitions)
+
+        # Use current_grid's space
+        used_offsets = {
+            d: 0 for d in range(len(grid_ggd.space[0].objects_per_dimension))
+        }
+
+        for p in range(num_partitions):
+            subset = grid_ggd.grid_subset[p]
+            name = vtk_pdsc.GetMetaData(p).Get(vtk_pdsc.NAME())
+            pds = vtk_pdsc.GetPartitionedDataSet(p)
+            ug = pds.GetPartition(0) if pds.GetNumberOfPartitions() > 0 else None
+
+            if ug is None:
+                subset.element.resize(0)
+                subset.dimension = 1
+                continue
+
+            n_cells = ug.GetNumberOfCells()
+            if n_cells == 0 and ug.GetNumberOfPoints() > 0:
+                cell_dim = 0
+                n_elem = ug.GetNumberOfPoints()
+            else:
+                cell_dim = ug.GetCell(0).GetCellDimension() if n_cells > 0 else 0
+                n_elem = n_cells
+
+            subset.dimension = cell_dim + 1
+            norm = name.lower().replace("-", "_").replace(" ", "_")
+            sid = getattr(identifiers.ggd_subset_identifier, norm, None)
+            if sid:
+                subset.identifier = sid
+
+            subset.element.resize(n_elem)
+            for i in range(n_elem):
+                el = subset.element[i]
+                el.object.resize(1)
+                obj = el.object[0]
+                obj.space = 1
+                obj.dimension = subset.dimension
+                if cell_dim == 0:
+                    obj.index = i + 1
+                else:
+                    obj.index = used_offsets[cell_dim] + i + 1
+
+            used_offsets[cell_dim] += n_elem

--- a/imas_paraview/vtk2ggd.py
+++ b/imas_paraview/vtk2ggd.py
@@ -11,7 +11,12 @@ from vtkmodules.vtkCommonDataModel import (
     vtkUnstructuredGrid,
 )
 
-from imas_paraview.util import create_first_grid, int32array, vtk_cells_to_nodes
+from imas_paraview.util import (
+    cart_to_pol,
+    create_first_grid,
+    int32array,
+    vtk_cells_to_nodes,
+)
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -26,11 +31,13 @@ class VTK2GGDConverter:
         vtk_objects: list[vtkPartitionedDataSetCollection],
         ids_name,
         dd_version=None,
+        cylindrical_coordinates=False,
     ):
         self.ids_name = ids_name
         self.factory = imas.IDSFactory(version=dd_version)
         self.dd_version = self.factory.version
         self.vtk_objects = vtk_objects
+        self.cylindrical_coordinates = cylindrical_coordinates
 
     def convert(self):
         """Converts a list of vtkPartitionedDataSetCollections into a single IDS. Each
@@ -116,12 +123,16 @@ class VTK2GGDConverter:
         # NOTE: We only support non-fourier grids
         space.geometry_type.index = 0
 
-        # NOTE: We only support X,Y,Z coordinates
+        # NOTE: We only support cartesian or cylindrical coordinates
         space.coordinates_type.resize(3)
         coord = identifiers.coordinate_identifier
+        if self.cylindrical_coordinates:
+            coord_space = [coord.r, coord.phi, coord.z]
+        else:
+            coord_space = [coord.x, coord.y, coord.z]
 
         # coordinates_type changed from INT_1D to an AoS of identifiers in DD4.0.0
-        for i, coord_identifier in enumerate([coord.x, coord.y, coord.z]):
+        for i, coord_identifier in enumerate(coord_space):
             if isinstance(space.coordinates_type, IDSStructure):
                 space.coordinates_type[i] = coord_identifier
             else:
@@ -153,7 +164,11 @@ class VTK2GGDConverter:
         if points is not None:
             space.objects_per_dimension[0].object.resize(len(points))
             for point, obj in zip(points, space.objects_per_dimension[0].object):
-                obj.geometry = point
+                if self.cylindrical_coordinates:
+                    r, phi = cart_to_pol(point[0], point[1])
+                    obj.geometry = [r, phi, point[2]]
+                else:
+                    obj.geometry = point
 
         # Fill cells
         for dim, cells in objects_per_dimension.items():

--- a/imas_paraview/vtk2ggd.py
+++ b/imas_paraview/vtk2ggd.py
@@ -18,10 +18,11 @@ logger = logging.getLogger(__name__)
 
 
 class VTK2GGDConverter:
-    """
-    Handles the back-conversion of multiple VTK objects into a single
+    """Handles the conversion of multiple vtkPartitionedDataSetCollections into a single
     IMAS GGD structure with multiple time steps.
     """
+
+    # TODO: docstrings, extra unit tests, cleanup of grid subset logic
 
     def __init__(
         self,
@@ -190,10 +191,13 @@ class VTK2GGDConverter:
                 n_elem = n_cells
 
             subset.dimension = cell_dim + 1
-            norm = name.lower().replace("-", "_").replace(" ", "_")
-            sid = getattr(identifiers.ggd_subset_identifier, norm, None)
-            if sid:
-                subset.identifier = sid
+            identifier_name = name.lower().replace("-", "_").replace(" ", "_")
+            if identifier_name in [m.name for m in identifiers.ggd_subset_identifier]:
+                subset.identifier = identifiers.ggd_subset_identifier[identifier_name]
+            else:
+                subset.identifier.name = identifier_name
+                subset.identifier.index = 0
+                subset.identifier.description = "Unknown subset identifier"
 
             subset.element.resize(n_elem)
             for i in range(n_elem):

--- a/imas_paraview/vtk2ggd.py
+++ b/imas_paraview/vtk2ggd.py
@@ -119,12 +119,19 @@ class VTK2GGDConverter:
         # NOTE: We only support X,Y,Z coordinates
         space.coordinates_type.resize(3)
         coord = identifiers.coordinate_identifier
+
+        # GGD2VTK converts coordinates differently for wall than from other IDSs
+        if self.ids_name == "wall":
+            coord_identifiers = [coord.x, coord.z, coord.y]
+        else:
+            coord_identifiers = [coord.x, coord.y, coord.z]
+
         # coordinates_type changed from INT_1D to an AoS of identifiers in DD4.0.0
-        for i, c in enumerate([coord.x, coord.y, coord.z]):
+        for i, coord_identifier in enumerate(coord_identifiers):
             if isinstance(space.coordinates_type, IDSStructure):
-                space.coordinates_type[i] = c
+                space.coordinates_type[i] = coord_identifier
             else:
-                space.coordinates_type[i] = c.index
+                space.coordinates_type[i] = coord_identifier.index
         max_dim = self._get_max_dimension(vtk_pdsc)
         space.objects_per_dimension.resize(max_dim + 1)
         return space
@@ -151,14 +158,11 @@ class VTK2GGDConverter:
         # Fill nodes
         if points is not None:
             space.objects_per_dimension[0].object.resize(len(points))
-            for i, p in enumerate(points):
-                obj = space.objects_per_dimension[0].object[i]
-                obj.geometry.resize(3)
+            for point, obj in zip(points, space.objects_per_dimension[0].object):
                 # GGD2VTK converts coordinates differently for wall than from other IDSs
-                if self.ids_name == "wall":
-                    obj.geometry[:] = [p[0], p[1], p[2]]
-                else:
-                    obj.geometry[:] = [p[0], p[2], p[1]]
+                if self.ids_name != "wall":
+                    point = [point[0], point[2], point[1]]
+                obj.geometry = point
 
         # Fill cells
         for dim, cells in objects_per_dimension.items():
@@ -235,18 +239,17 @@ class VTK2GGDConverter:
             subset.dimension = cell_dim + 1
 
             identifier_name = name.lower().replace("-", "_").replace(" ", "_")
-            if identifier_name in [m.name for m in identifiers.ggd_subset_identifier]:
+            try:
                 subset.identifier = identifiers.ggd_subset_identifier[identifier_name]
-            else:
+            except KeyError:
                 subset.identifier.name = identifier_name
                 subset.identifier.index = 0
                 subset.identifier.description = "Unknown subset identifier"
 
             subset.element.resize(n_elem)
-            for i in range(n_elem):
-                el = subset.element[i]
-                el.object.resize(1)
-                obj = el.object[0]
+            for i, element in enumerate(subset.element):
+                element.object.resize(1)
+                obj = element.object[0]
                 obj.space = 1
                 obj.dimension = subset.dimension
                 if cell_dim == 0:

--- a/imas_paraview/vtk2ggd.py
+++ b/imas_paraview/vtk2ggd.py
@@ -120,14 +120,8 @@ class VTK2GGDConverter:
         space.coordinates_type.resize(3)
         coord = identifiers.coordinate_identifier
 
-        # GGD2VTK converts coordinates differently for wall than from other IDSs
-        if self.ids_name == "wall":
-            coord_identifiers = [coord.x, coord.z, coord.y]
-        else:
-            coord_identifiers = [coord.x, coord.y, coord.z]
-
         # coordinates_type changed from INT_1D to an AoS of identifiers in DD4.0.0
-        for i, coord_identifier in enumerate(coord_identifiers):
+        for i, coord_identifier in enumerate([coord.x, coord.y, coord.z]):
             if isinstance(space.coordinates_type, IDSStructure):
                 space.coordinates_type[i] = coord_identifier
             else:
@@ -159,9 +153,6 @@ class VTK2GGDConverter:
         if points is not None:
             space.objects_per_dimension[0].object.resize(len(points))
             for point, obj in zip(points, space.objects_per_dimension[0].object):
-                # GGD2VTK converts coordinates differently for wall than from other IDSs
-                if self.ids_name != "wall":
-                    point = [point[0], point[2], point[1]]
                 obj.geometry = point
 
         # Fill cells

--- a/imas_paraview/vtk2ggd.py
+++ b/imas_paraview/vtk2ggd.py
@@ -18,11 +18,8 @@ logger = logging.getLogger(__name__)
 
 
 class VTK2GGDConverter:
-    """Handles the conversion of multiple vtkPartitionedDataSetCollections into a single
-    IMAS GGD structure with multiple time steps.
-    """
-
-    # TODO: docstrings, extra unit tests, cleanup of grid subset logic
+    """Handles the conversion of multiple vtkPartitionedDataSetCollections, where
+    each vtkPartitionedDataSetCollection contains a grid for a single time step."""
 
     def __init__(
         self,
@@ -36,15 +33,33 @@ class VTK2GGDConverter:
         self.vtk_objects = vtk_objects
 
     def convert(self):
+        """Converts a list of vtkPartitionedDataSetCollections into a single IDS. Each
+        vtkPartitionedDataSetCollection must contain a single partition containing a
+        vtkUnstructuredGrid.
+
+        Returns:
+            An IDS containing the converted GGD grid for all time steps.
+        """
         ids, grid_ggd = self._setup_ids()
 
         # Each partitioned dataset collection in the list contains the grid for a
         # single time step
         for time_idx, vtk_pdsc in enumerate(self.vtk_objects):
-            # TODO: Only support linear grids
+            # NOTE: We only support linear grids
             grid_ggd[time_idx].identifier = identifiers.ggd_identifier.linear
 
-            self._set_time_step(ids, time_idx, vtk_pdsc)
+            time = self._get_time_step(vtk_pdsc)
+            if time is not None:
+                logger.info("Converting time step %d: t = %f", time_idx, time)
+            else:
+                logger.warning(
+                    "The vtkPartitionedDataSetCollection at time index %d does not "
+                    "have a time value. Using index as the time value instead.",
+                    time_idx,
+                )
+                time = time_idx
+            ids.time[time_idx] = time
+
             space = self._setup_space(grid_ggd[time_idx], vtk_pdsc)
 
             self._fill_space(space, vtk_pdsc)
@@ -53,6 +68,12 @@ class VTK2GGDConverter:
         return ids
 
     def _setup_ids(self):
+        """Create and initialize the IDS and its GGD grid structure.
+
+        Returns:
+            ids: The initialized IDS.
+            grid_ggd: The GGD grid AoS for the created IDS.
+        """
         ids = self.factory.new(self.ids_name)
         first_grid = create_first_grid(ids)
         if not first_grid:
@@ -63,85 +84,42 @@ class VTK2GGDConverter:
         ids.time = np.zeros(num_steps)
         grid_ggd.resize(num_steps)
 
-        # TODO: only support HOMOGENEOUS TIME for now
+        # NOTE: We only support IDSs with a homogeneous time mode
         ids.ids_properties.homogeneous_time = imas.ids_defs.IDS_TIME_MODE_HOMOGENEOUS
 
-        # Set version_put properties (version_put was added in DD 3.22)
-        if hasattr(ids.ids_properties, "version_put"):
-            version_put = ids.ids_properties.version_put
-            version_put.data_dictionary = self.dd_version
-            version_put.access_layer_language = f"IMAS-Python {imas.__version__}"
         return ids, grid_ggd
 
-    def _set_time_step(self, ids, time_idx, vtk_pdsc):
+    def _get_time_step(self, vtk_pdsc):
+        """Return the time value of the vtkPartitionedDataSetCollection, or None if it
+        does not contain any time information."""
         info = vtk_pdsc.GetInformation()
         if info.Has(vtk.vtkDataObject.DATA_TIME_STEP()):
             time = info.Get(vtk.vtkDataObject.DATA_TIME_STEP())
-            ids.time[time_idx] = time
-            logger.info("Converting time step %d: t = %f", time_idx, time)
-        else:
-            logger.warning(
-                "The vtkPartitionedDataSetCollection at time index %d does not have a "
-                "time value. Using index as the time value instead.",
-                time_idx,
-            )
-            ids.time[time_idx] = time_idx
-
-    def read_vtk(self, vtk_pdsc):
-        points = None
-        objects_by_dimension = {}
-
-        for i in range(vtk_pdsc.GetNumberOfPartitionedDataSets()):
-            partitioned_dataset = vtk_pdsc.GetPartitionedDataSet(i)
-            # GGD2VTK only fills first partition of a partitioned dataset
-            ugrid = partitioned_dataset.GetPartition(0)
-            if ugrid is None or not isinstance(ugrid, vtkUnstructuredGrid):
-                logger.warning("partition %d does not contain an unstructured grid", i)
-                continue
-            if points is None and ugrid.GetNumberOfPoints() > 0:
-                points = vtk_to_numpy(ugrid.GetPoints().GetData()).astype(np.float64)
-            if ugrid.GetNumberOfCells() > 0:
-                dim = ugrid.GetCell(0).GetCellDimension()
-                if dim > 0:
-                    objects_by_dimension.setdefault(dim, []).extend(
-                        vtk_cells_to_nodes(ugrid.GetCells())
-                    )
-        return points, objects_by_dimension
-
-    def _fill_space(self, space, vtk_pdsc):
-        points, objects_by_dimension = self.read_vtk(vtk_pdsc)
-        # Fill nodes
-        if points is not None:
-            space.objects_per_dimension[0].object.resize(len(points))
-            for i, p in enumerate(points):
-                obj = space.objects_per_dimension[0].object[i]
-                obj.geometry.resize(3)
-                # Wall converts coordinates differently from other IDSs
-                if self.ids_name == "wall":
-                    obj.geometry[:] = [p[0], p[1], p[2]]
-                else:
-                    obj.geometry[:] = [p[0], p[2], p[1]]
-
-        # Fill cells
-        for dim, cells in objects_by_dimension.items():
-            space.objects_per_dimension[dim].object.resize(len(cells))
-            for i, nodes in enumerate(cells):
-                obj = space.objects_per_dimension[dim].object[i]
-                obj.nodes = int32array(nodes)
+            return time
+        return None
 
     def _setup_space(self, grid_ggd, vtk_pdsc):
-        # TODO: Only support creating a single space, I think multiple spaces are
-        # lost upon conversion
+        """Initialize and configure the GGD space definition for a grid.
+
+        Args:
+            grid_ggd: GGD grid structure for the current time step.
+            vtk_pdsc: VTK partitioned dataset collection used for dimension inference.
+
+        Returns:
+            Initialized GGD space structure.
+        """
+        # NOTE: We only support creating a single GGD space
         grid_ggd.space.resize(1)
         space = grid_ggd.space[0]
-        # NOTE: Only support primary standard spaces
+        # NOTE: We only support primary standard spaces
         space.identifier = identifiers.ggd_space_identifier.primary_standard
-        # NOTE: Only support non-fourier grids
+        # NOTE: We only support non-fourier grids
         space.geometry_type.index = 0
-        # coordinates_type changed from INT_1D to an AoS of identifiers in DD4.0.0
+
+        # NOTE: We only support X,Y,Z coordinates
         space.coordinates_type.resize(3)
-        # NOTE: Only support X,Y,Z coordinates
         coord = identifiers.coordinate_identifier
+        # coordinates_type changed from INT_1D to an AoS of identifiers in DD4.0.0
         for i, c in enumerate([coord.x, coord.y, coord.z]):
             if isinstance(space.coordinates_type, IDSStructure):
                 space.coordinates_type[i] = c
@@ -152,21 +130,87 @@ class VTK2GGDConverter:
         return space
 
     def _get_max_dimension(self, vtk_pdsc):
+        """Returns the maximum cell dimension in the vtkPartitionedDataSetCollection."""
         max_dimension = 0
         for i in range(vtk_pdsc.GetNumberOfPartitionedDataSets()):
             pds = vtk_pdsc.GetPartitionedDataSet(i)
-            ug = pds.GetPartition(0) if pds.GetNumberOfPartitions() > 0 else None
-            if ug and ug.GetNumberOfCells() > 0:
-                max_dimension = max(max_dimension, ug.GetCell(0).GetCellDimension())
+            ugrid = pds.GetPartition(0) if pds.GetNumberOfPartitions() > 0 else None
+            if ugrid and ugrid.GetNumberOfCells() > 0:
+                max_dimension = max(max_dimension, ugrid.GetCell(0).GetCellDimension())
         return max_dimension
 
+    def _fill_space(self, space, vtk_pdsc):
+        """Populate a GGD space with node coordinates and cell connectivities.
+
+        Args:
+            space: GGD space structure to populate.
+            vtk_pdsc: vtkPartitionedDataSetCollection to read data from.
+        """
+        points, objects_per_dimension = self.extract_data_from_pdsc(vtk_pdsc)
+
+        # Fill nodes
+        if points is not None:
+            space.objects_per_dimension[0].object.resize(len(points))
+            for i, p in enumerate(points):
+                obj = space.objects_per_dimension[0].object[i]
+                obj.geometry.resize(3)
+                # GGD2VTK converts coordinates differently for wall than from other IDSs
+                if self.ids_name == "wall":
+                    obj.geometry[:] = [p[0], p[1], p[2]]
+                else:
+                    obj.geometry[:] = [p[0], p[2], p[1]]
+
+        # Fill cells
+        for dim, cells in objects_per_dimension.items():
+            space.objects_per_dimension[dim].object.resize(len(cells))
+            for i, nodes in enumerate(cells):
+                obj = space.objects_per_dimension[dim].object[i]
+                obj.nodes = int32array(nodes)
+
+    def extract_data_from_pdsc(self, vtk_pdsc):
+        """Extract point coordinates and cell connectivities grouped by dimension from
+        a vtkPartitionedDataSetCollection.
+
+        Args:
+            vtk_pdsc: vtkPartitionedDataSetCollection to extract data from.
+
+        Returns:
+            points: Array containing the x,y,z-points
+            objects_per_dimension: Dictionary mapping dimension to node lists.
+        """
+        points = None
+        objects_per_dimension = {}
+
+        for i in range(vtk_pdsc.GetNumberOfPartitionedDataSets()):
+            partitioned_dataset = vtk_pdsc.GetPartitionedDataSet(i)
+            # NOTE: We only read the first partition here, as GGD2VTK only fills first
+            # partition of a partitioned dataset
+            ugrid = partitioned_dataset.GetPartition(0)
+            if ugrid is None or not isinstance(ugrid, vtkUnstructuredGrid):
+                logger.warning("partition %d does not contain an unstructured grid", i)
+                continue
+            if points is None and ugrid.GetNumberOfPoints() > 0:
+                points = vtk_to_numpy(ugrid.GetPoints().GetData()).astype(np.float64)
+            if ugrid.GetNumberOfCells() > 0:
+                dim = ugrid.GetCell(0).GetCellDimension()
+                if dim > 0:
+                    objects_per_dimension.setdefault(dim, []).extend(
+                        vtk_cells_to_nodes(ugrid.GetCells())
+                    )
+        return points, objects_per_dimension
+
     def _build_grid_subsets(self, grid_ggd, vtk_pdsc):
+        """Create grid subsets mapping partitions of a vtkPartitionedDataSetCollection
+        to GGD subset definitions.
+
+        Args:
+            grid_ggd: GGD grid structure for the current time step, in which the
+                grid subsets will be stored.
+            vtk_pdsc: the vtkPartitionedDataSetCollection to load partitions from.
+        """
         num_partitions = vtk_pdsc.GetNumberOfPartitionedDataSets()
         grid_ggd.grid_subset.resize(num_partitions)
 
-        # TODO add pytests for grid_subsets
-
-        # Use current_grid's space
         used_offsets = dict.fromkeys(
             range(len(grid_ggd.space[0].objects_per_dimension)), 0
         )
@@ -175,22 +219,21 @@ class VTK2GGDConverter:
             subset = grid_ggd.grid_subset[p]
             name = vtk_pdsc.GetMetaData(p).Get(vtk_pdsc.NAME())
             pds = vtk_pdsc.GetPartitionedDataSet(p)
-            ug = pds.GetPartition(0) if pds.GetNumberOfPartitions() > 0 else None
+            ugrid = pds.GetPartition(0) if pds.GetNumberOfPartitions() > 0 else None
 
-            if ug is None:
-                subset.element.resize(0)
-                subset.dimension = 1
+            if ugrid is None:
                 continue
 
-            n_cells = ug.GetNumberOfCells()
-            if n_cells == 0 and ug.GetNumberOfPoints() > 0:
+            # Get number of elements for this subset
+            n_cells = ugrid.GetNumberOfCells()
+            if n_cells == 0 and ugrid.GetNumberOfPoints() > 0:
                 cell_dim = 0
-                n_elem = ug.GetNumberOfPoints()
+                n_elem = ugrid.GetNumberOfPoints()
             else:
-                cell_dim = ug.GetCell(0).GetCellDimension() if n_cells > 0 else 0
+                cell_dim = ugrid.GetCell(0).GetCellDimension() if n_cells > 0 else 0
                 n_elem = n_cells
-
             subset.dimension = cell_dim + 1
+
             identifier_name = name.lower().replace("-", "_").replace(" ", "_")
             if identifier_name in [m.name for m in identifiers.ggd_subset_identifier]:
                 subset.identifier = identifiers.ggd_subset_identifier[identifier_name]

--- a/imas_paraview/vtk2ggd.py
+++ b/imas_paraview/vtk2ggd.py
@@ -163,10 +163,12 @@ class VTK2GGDConverter:
         num_partitions = vtk_pdsc.GetNumberOfPartitionedDataSets()
         grid_ggd.grid_subset.resize(num_partitions)
 
+        # TODO add pytests for grid_subsets
+
         # Use current_grid's space
-        used_offsets = {
-            d: 0 for d in range(len(grid_ggd.space[0].objects_per_dimension))
-        }
+        used_offsets = dict.fromkeys(
+            range(len(grid_ggd.space[0].objects_per_dimension)), 0
+        )
 
         for p in range(num_partitions):
             subset = grid_ggd.grid_subset[p]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ benchmark=[
 [project.scripts]
 imas-paraview = "imas_paraview.cli:cli"
 ggd2vtk = "imas_paraview.cli:convert_ggd_to_vtk"
+vtk2ggd = "imas_paraview.cli:convert_vtk_to_ggd"
 
 [project.urls]
 homepage = "https://github.com/iterorganization/IMAS-ParaView"


### PR DESCRIPTION
This introduces the CLI command `vtk2ggd` which can convert VTK objects into an IDS containing GGD grids. Note that there are strict limitations on the type of VTK data the converter expects, and how it is structured. This has been written in the documentation. 

Besides testing the conversion with a generated dummy GGD unit test, I also validated the conversion using real IDS datasets. For each case, I first ran the `ggd2vtk` command, then converted the resulting VTK files back to GGD using `vtk2ggd`, and visually inspected the GGD grid and its subsets in ParaView:
 
- SOLPS: `imas:hdf5?path=/work/imas/shared/imasdb/ITER_SCENARIOS/3/123356/1`, with `edge_profiles` IDS
- JOREK: `imas:hdf5?user=public;pulse=112111;run=2;database=ITER_DISRUPTIONS;version=4`, with `wall` IDS
- MD: `iter_md_wall_116100_2001.nc`from [Zenodo](https://zenodo.org/records/17113713), with `wall` IDS. (Conversion of this dataset takes quite long (>1 minute), which is why it was not included as a unit test).
