### PR TITLE
Fix error when loading empty GGD grid

### DIFF
--- a/imas_paraview/convert.py
+++ b/imas_paraview/convert.py
@@ -113,7 +113,7 @@ class Converter:
         if time is None:
             time = self.ids.time[self.time_idx]
 
-        self.grid_ggd = get_grid_ggd(self.ids, time, parent_idx)
+        self.grid_ggd = get_grid_ggd(self.ids, time=time, parent_idx=parent_idx)
         if self.grid_ggd is None:
             logger.error("Could not load a valid GGD grid.")
             return None

--- a/imas_paraview/tests/test_util.py
+++ b/imas_paraview/tests/test_util.py
@@ -1,9 +1,10 @@
+import imas
 import numpy as np
 import pytest
 import vtk
 from vtk.util.numpy_support import vtk_to_numpy
 
-from imas_paraview.util import find_closest_indices, points_to_vtkpoly
+from imas_paraview.util import find_closest_indices, get_grid_ggd, points_to_vtkpoly
 
 
 @pytest.fixture
@@ -72,3 +73,35 @@ def test_points_to_vtkpoly_filled_polygon(points):
 def test_points_to_vtkpoly_filled_requires_closed(points):
     with pytest.raises(ValueError):
         points_to_vtkpoly(points, is_closed=False, is_filled=True)
+
+
+def test_get_grid_ggd():
+    dd_version = "4.0.0"
+    ids = imas.IDSFactory(version=dd_version).new("edge_profiles")
+    ids.time = [0.0, 1.1, 2.2]
+    ids.ids_properties.homogeneous_time = imas.ids_defs.IDS_TIME_MODE_HOMOGENEOUS
+    assert get_grid_ggd(ids) is None
+    ids.grid_ggd.resize(3)
+    # Test with id() otherwise IDSStructure will compare contents of structure
+    assert id(get_grid_ggd(ids)) == id(ids.grid_ggd[0])
+    assert id(get_grid_ggd(ids, time=1.1)) == id(ids.grid_ggd[1])
+    assert id(get_grid_ggd(ids, time=2.2)) == id(ids.grid_ggd[2])
+
+    ids = imas.IDSFactory(version=dd_version).new("wall")
+    ids.time = [0.0]
+    ids.ids_properties.homogeneous_time = imas.ids_defs.IDS_TIME_MODE_HOMOGENEOUS
+    assert get_grid_ggd(ids) is None
+    ids.description_ggd.resize(2)
+    ids.description_ggd[0].grid_ggd.resize(1)
+    ids.description_ggd[1].grid_ggd.resize(1)
+    assert id(get_grid_ggd(ids)) == id(ids.description_ggd[0].grid_ggd[0])
+    assert id(get_grid_ggd(ids, parent_idx=1)) == id(ids.description_ggd[1].grid_ggd[0])
+
+    ids = imas.IDSFactory(version=dd_version).new("equilibrium")
+    ids.time = [0.0]
+    ids.ids_properties.homogeneous_time = imas.ids_defs.IDS_TIME_MODE_HOMOGENEOUS
+    assert get_grid_ggd(ids) is None
+    ids.grids_ggd.resize(1)
+    assert get_grid_ggd(ids) is None
+    ids.grids_ggd[0].grid.resize(1)
+    assert id(get_grid_ggd(ids)) == id(ids.grids_ggd[0].grid[0])

--- a/imas_paraview/tests/test_util.py
+++ b/imas_paraview/tests/test_util.py
@@ -84,8 +84,12 @@ def test_get_grid_ggd():
     ids.grid_ggd.resize(3)
     # Test with id() otherwise IDSStructure will compare contents of structure
     assert id(get_grid_ggd(ids)) == id(ids.grid_ggd[0])
+    assert id(get_grid_ggd(ids, time=0.5)) == id(ids.grid_ggd[0])
+    assert id(get_grid_ggd(ids, time=-0.5)) == id(ids.grid_ggd[0])
     assert id(get_grid_ggd(ids, time=1.1)) == id(ids.grid_ggd[1])
+    assert id(get_grid_ggd(ids, time=2.0)) == id(ids.grid_ggd[1])
     assert id(get_grid_ggd(ids, time=2.2)) == id(ids.grid_ggd[2])
+    assert id(get_grid_ggd(ids, time=3.3)) == id(ids.grid_ggd[2])
 
     ids = imas.IDSFactory(version=dd_version).new("wall")
     ids.time = [0.0]
@@ -96,6 +100,7 @@ def test_get_grid_ggd():
     ids.description_ggd[1].grid_ggd.resize(1)
     assert id(get_grid_ggd(ids)) == id(ids.description_ggd[0].grid_ggd[0])
     assert id(get_grid_ggd(ids, parent_idx=1)) == id(ids.description_ggd[1].grid_ggd[0])
+    assert get_grid_ggd(ids, parent_idx=2) is None
 
     ids = imas.IDSFactory(version=dd_version).new("equilibrium")
     ids.time = [0.0]
@@ -105,3 +110,8 @@ def test_get_grid_ggd():
     assert get_grid_ggd(ids) is None
     ids.grids_ggd[0].grid.resize(1)
     assert id(get_grid_ggd(ids)) == id(ids.grids_ggd[0].grid[0])
+
+    ids = imas.IDSFactory(version=dd_version).new("camera_ir")  # IDS without GGD grid
+    ids.time = [0.0]
+    ids.ids_properties.homogeneous_time = imas.ids_defs.IDS_TIME_MODE_HOMOGENEOUS
+    assert get_grid_ggd(ids) is None

--- a/imas_paraview/util.py
+++ b/imas_paraview/util.py
@@ -97,7 +97,6 @@ def get_grid_ggd(ids, time=0.0, parent_idx=0):
             continue
         elif isinstance(node, IDSStructArray):
             if len(node) == 0:
-                logger.error("'%s' array of structures is empty.")
                 return None
 
             # Time dependent array of structure

--- a/imas_paraview/util.py
+++ b/imas_paraview/util.py
@@ -69,7 +69,7 @@ def get_ggd_path(ids_metadata) -> Optional[str]:
     return None
 
 
-def get_grid_ggd(ids, time=0, parent_idx=0):
+def get_grid_ggd(ids, time=0.0, parent_idx=0):
     """Finds and returns the grid_ggd within IDS at the time index ggd_idx. If the
     grid_ggd at ggd_idx time index does not exist, it tries to return the first
     grid_ggd. If this does not exist, it returns None.
@@ -103,6 +103,9 @@ def get_grid_ggd(ids, time=0, parent_idx=0):
             if 0 <= ggd_idx < len(node):
                 node = node[ggd_idx]
             else:
+                if len(node) == 0:
+                    return None
+
                 node = node[0]
                 logger.warning(
                     "The GGD grid was not found at time index %d, so first "
@@ -110,6 +113,8 @@ def get_grid_ggd(ids, time=0, parent_idx=0):
                     ggd_idx,
                 )
         else:
+            if len(node) == 0:
+                return None
             node = node[parent_idx]
 
     return node

--- a/imas_paraview/util.py
+++ b/imas_paraview/util.py
@@ -95,36 +95,34 @@ def get_grid_ggd(ids, time=0.0, parent_idx=0):
         node = node[path]
         if isinstance(node, IDSStructure):
             continue
-        elif isinstance(node, IDSStructArray):
-            if len(node) == 0:
-                return None
 
-            # Time dependent array of structure
-            if node.metadata.coordinate1.is_time_coordinate:
-                # Let IMAS-Python handle the time mode (homogeneous/heterogeneous):
-                time_array = node.coordinates[0]
-                # Load closest previous time index
-                ggd_idx = np.searchsorted(time_array, time, side="right") - 1
-
-                if ggd_idx < 0:
-                    ggd_idx = 0
-
-                try:
-                    node = node[ggd_idx]
-                except IndexError:
-                    node = node[0]
-                    logger.warning(
-                        "The GGD grid was not found at time index %d, so first "
-                        "grid was loaded instead.",
-                        ggd_idx,
-                    )
-            else:
-                try:
-                    node = node[parent_idx]
-                except IndexError:
-                    return None
-        else:
+        if len(node) == 0:
             return None
+
+        # Time dependent array of structure
+        if node.metadata.coordinate1.is_time_coordinate:
+            # Let IMAS-Python handle the time mode (homogeneous/heterogeneous):
+            time_array = node.coordinates[0]
+            # Load closest previous time index
+            ggd_idx = np.searchsorted(time_array, time, side="right") - 1
+
+            if ggd_idx < 0:
+                ggd_idx = 0
+
+            try:
+                node = node[ggd_idx]
+            except IndexError:
+                node = node[0]
+                logger.warning(
+                    "The GGD grid was not found at time index %d, so first "
+                    "grid was loaded instead.",
+                    ggd_idx,
+                )
+        else:
+            try:
+                node = node[parent_idx]
+            except IndexError:
+                return None
 
     return node
 

--- a/imas_paraview/util.py
+++ b/imas_paraview/util.py
@@ -3,7 +3,6 @@ from typing import Optional
 
 import imas
 import numpy as np
-from imas.ids_struct_array import IDSStructArray
 from imas.ids_structure import IDSStructure
 from vtk import vtkDataObject, vtkStreamingDemandDrivenPipeline
 from vtkmodules.util.numpy_support import numpy_to_vtk, vtk_to_numpy

--- a/imas_paraview/util.py
+++ b/imas_paraview/util.py
@@ -3,6 +3,8 @@ from typing import Optional
 
 import imas
 import numpy as np
+from imas.ids_struct_array import IDSStructArray
+from imas.ids_structure import IDSStructure
 from vtk import vtkDataObject, vtkStreamingDemandDrivenPipeline
 from vtkmodules.util.numpy_support import numpy_to_vtk, vtk_to_numpy
 from vtkmodules.vtkCommonCore import vtkPoints
@@ -70,9 +72,8 @@ def get_ggd_path(ids_metadata) -> Optional[str]:
 
 
 def get_grid_ggd(ids, time=0.0, parent_idx=0):
-    """Finds and returns the grid_ggd within IDS at the time index ggd_idx. If the
-    grid_ggd at ggd_idx time index does not exist, it tries to return the first
-    grid_ggd. If this does not exist, it returns None.
+    """Returns the GGD grid within IDS at a specific time. If the GGD grid does not
+    exist at the corresponding time index, it returns the first GGD grid instead.
 
     Args:
         ids: The IDS for which to return the grid_gdd.
@@ -86,36 +87,45 @@ def get_grid_ggd(ids, time=0.0, parent_idx=0):
     """
     grid_path = get_ggd_grid_path(ids.metadata)
     if grid_path is None:
+        logger.error("'%s' IDS does not contain a GGD grid.", ids.metadata.name)
         return None
 
     node = ids
     for path in grid_path.split("/"):
         node = node[path]
-        if node.metadata.ndim == 0:
-            pass  # Current node is a structure
-        elif node.metadata.coordinate1.is_time_coordinate:
-            # Time dependent array of structure
-            # Let IMAS-Python handle the time mode (homogeneous/heterogeneous):
-            time_array = node.coordinates[0]
-            # Load closest previous time index
-            ggd_idx = np.searchsorted(time_array, time, side="right") - 1
-
-            if 0 <= ggd_idx < len(node):
-                node = node[ggd_idx]
-            else:
-                if len(node) == 0:
-                    return None
-
-                node = node[0]
-                logger.warning(
-                    "The GGD grid was not found at time index %d, so first "
-                    "grid was loaded instead.",
-                    ggd_idx,
-                )
-        else:
+        if isinstance(node, IDSStructure):
+            continue
+        elif isinstance(node, IDSStructArray):
             if len(node) == 0:
+                logger.error("'%s' array of structures is empty.")
                 return None
-            node = node[parent_idx]
+
+            # Time dependent array of structure
+            if node.metadata.coordinate1.is_time_coordinate:
+                # Let IMAS-Python handle the time mode (homogeneous/heterogeneous):
+                time_array = node.coordinates[0]
+                # Load closest previous time index
+                ggd_idx = np.searchsorted(time_array, time, side="right") - 1
+
+                if ggd_idx < 0:
+                    ggd_idx = 0
+
+                try:
+                    node = node[ggd_idx]
+                except IndexError:
+                    node = node[0]
+                    logger.warning(
+                        "The GGD grid was not found at time index %d, so first "
+                        "grid was loaded instead.",
+                        ggd_idx,
+                    )
+            else:
+                try:
+                    node = node[parent_idx]
+                except IndexError:
+                    return None
+        else:
+            return None
 
     return node
 


### PR DESCRIPTION
Previously the GGD reader would raise an error when trying to load an empty GGD grid. This has now been handled more gracefully.