### PR TITLE
Update github actions to latest versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,10 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
 
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v6
       with:
         python-version: '3.11'
 
@@ -34,12 +34,12 @@ jobs:
       paraview-download-file: ParaView-5.13.3-MPI-Linux-Python3.10-x86_64.tar.gz
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         # Note: Python version **must** match the one in the paraview binaries
         python-version: '3.10'
@@ -57,7 +57,7 @@ jobs:
 
     - name: Cache Zenodo datasets
       id: cache-datasets
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       with:
         path: data
         key: ${{ steps.datasets.outputs.key }}
@@ -74,14 +74,14 @@ jobs:
     - name: Always save Zenodo datasets (even if pytest would fail)
       id: cache-datasets-save
       if: always() && steps.cache-datasets.outputs.cache-hit != 'true'
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v5
       with:
         key: ${{ steps.cache-datasets.outputs.cache-primary-key }}
         path: data
 
     - name: Cache paraview
       id: cache-paraview
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       with:
         path: paraview/
         key: ${{ env.paraview-download-file }}
@@ -96,7 +96,7 @@ jobs:
     - name: Always save cache (even if pytest would fail)
       id: cache-paraview-save
       if: always() && steps.cache-paraview.outputs.cache-hit != 'true'
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v5
       with:
         key: ${{ steps.cache-paraview.outputs.cache-primary-key }}
         path: paraview/
@@ -122,7 +122,7 @@ jobs:
         pvpython --venv venv -m pytest --skip-mdsplus --skip-hdf5 --cov=imas_paraview --cov-report=term-missing --cov-report=html
 
     - name: Upload coverage report
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: coverage-report-3.11
         path: htmlcov
@@ -133,7 +133,7 @@ jobs:
     needs: pytest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0
 
@@ -145,7 +145,7 @@ jobs:
         git show-ref --verify --quiet refs/heads/main || git branch main origin/main
 
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v6
       with:
         python-version: '3.11'
 
@@ -177,7 +177,7 @@ jobs:
         asv publish
 
     - name: Upload HTML reports as artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: asv-html-reports
         path: .asv/html
@@ -188,10 +188,10 @@ jobs:
     needs: pytest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
 
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v6
       with:
         python-version: '3.11'
 
@@ -205,7 +205,7 @@ jobs:
         make -C docs html
 
     - name: Upload docs artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: html-docs
         path: docs/_build/html/

--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -10,18 +10,18 @@ jobs:
     name: Build distribution
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
     - name: Install pypa/build
       run: >-
         python3 -m pip install pip setuptools wheel build
     - name: Build a binary wheel and a source tarball
       run: python3 -m build .
     - name: Store the distribution packages
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: python-package-distributions
         path: dist/
@@ -39,7 +39,7 @@ jobs:
       id-token: write  # IMPORTANT: mandatory for trusted publishing
     steps:
     - name: Download all the dists
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: python-package-distributions
         path: dist/


### PR DESCRIPTION
Update the github actions to the latest versions to get rid of the Node 20 deprecation warnings (for example [here](https://github.com/iterorganization/IMAS-ParaView/actions/runs/24724283166)).