### PR TITLE
Fix uri loading issue if occurrence 0 is missing

### DIFF
--- a/imas_paraview/plugins/base_class.py
+++ b/imas_paraview/plugins/base_class.py
@@ -504,8 +504,7 @@ class GGDVTKPluginBase(VTKPythonAlgorithmBase, ABC):
             return 1
 
         # Load IDS and available time steps
-        idsname, _, _ = self._ids_and_occurrence.partition("/")
-        if idsname not in self._ids_list:
+        if self._ids_and_occurrence not in self._ids_list:
             logger.error("Could not find the selected IDS.")
             self._selectable = []
             return 1


### PR DESCRIPTION
Fixes an issue which causes the readers to fail to load an IDS with occurrence>0 if occurrence=0 is missing. 

I have tested it by loading `edge_profiles/1` from the following URI, which doesn't contain an edge_profiles with occurrence=0: 

```
imas:hdf5?path=/home/ITER/blokhus/public/test_missing_ocurrence/test
```