### PR TITLE
Fix missing position issue

### DIFF
--- a/imas_paraview/ids_util.py
+++ b/imas_paraview/ids_util.py
@@ -177,9 +177,15 @@ def cart_vector_has_value(vec):
         return False
 
 
-def cyl_vector_has_value(vec):
-    """Check if a lazy-loaded cylindrical IMAS vector quantity has data."""
+def cyl_vector_has_value(vec, check_phi=True):
+    """Check if a lazy-loaded cylindrical IMAS vector quantity has data.
+
+    Args:
+        vec: IMAS structure with r, phi, z fields.
+        check_phi: Whether to require phi to be set.
+    """
     try:
-        return vec.r.has_value and vec.phi.has_value and vec.z.has_value
+        has_rz = vec.r.has_value and vec.z.has_value
+        return has_rz and (vec.phi.has_value if check_phi else True)
     except AttributeError:
         return False

--- a/imas_paraview/ids_util.py
+++ b/imas_paraview/ids_util.py
@@ -177,15 +177,19 @@ def cart_vector_has_value(vec):
         return False
 
 
-def cyl_vector_has_value(vec, check_phi=True):
-    """Check if a lazy-loaded cylindrical IMAS vector quantity has data.
+def cyl_vector_has_value(vec):
+    """Check if a lazy-loaded cylindrical IMAS vector quantity has data."""
+    try:
+        return vec.r.has_value and vec.phi.has_value and vec.z.has_value
+    except AttributeError:
+        return False
 
-    Args:
-        vec: IMAS structure with r, phi, z fields.
-        check_phi: Whether to require phi to be set.
+
+def rz_vector_has_value(vec):
+    """
+    Check if a lazy-loaded cylindrical IMAS vector quantity has at least r and z set.
     """
     try:
-        has_rz = vec.r.has_value and vec.z.has_value
-        return has_rz and (vec.phi.has_value if check_phi else True)
+        return vec.r.has_value and vec.z.has_value
     except AttributeError:
         return False

--- a/imas_paraview/plugins/position.py
+++ b/imas_paraview/plugins/position.py
@@ -8,7 +8,7 @@ from paraview.util.vtkAlgorithm import smhint, smproxy
 from vtkmodules.vtkCommonCore import vtkPoints
 from vtkmodules.vtkCommonDataModel import vtkPolyData
 
-from imas_paraview.ids_util import cyl_vector_has_value
+from imas_paraview.ids_util import rz_vector_has_value
 from imas_paraview.plugins.base_class import GGDVTKPluginBase
 from imas_paraview.util import ensure_unique_name, pol_to_cart
 
@@ -91,11 +91,9 @@ class PositionReader(GGDVTKPluginBase):
                 if isinstance(pos, IDSStructArray):
                     # Allow phi to be absent from the position vector, e.g. in the case
                     # of 2D rotationally symmetric representations
-                    has_valid_position = any(
-                        cyl_vector_has_value(p, check_phi=False) for p in pos
-                    )
+                    has_valid_position = any(rz_vector_has_value(p) for p in pos)
                 else:
-                    has_valid_position = cyl_vector_has_value(pos, check_phi=False)
+                    has_valid_position = rz_vector_has_value(pos)
 
                 if not has_valid_position:
                     logger.warning("Skipping %s: no position set.", name)

--- a/imas_paraview/plugins/position.py
+++ b/imas_paraview/plugins/position.py
@@ -8,8 +8,9 @@ from paraview.util.vtkAlgorithm import smhint, smproxy
 from vtkmodules.vtkCommonCore import vtkPoints
 from vtkmodules.vtkCommonDataModel import vtkPolyData
 
+from imas_paraview.ids_util import cyl_vector_has_value
 from imas_paraview.plugins.base_class import GGDVTKPluginBase
-from imas_paraview.util import pol_to_cart
+from imas_paraview.util import ensure_unique_name, pol_to_cart
 
 logger = logging.getLogger("imas_paraview")
 
@@ -74,7 +75,7 @@ class PositionReader(GGDVTKPluginBase):
             )
         for aos in aos_list:
             for i, structure in enumerate(aos):
-                name = structure.name
+                name = str(structure.name)
                 if name == "":
                     name = f"device {i}"
                     logger.warning(
@@ -86,8 +87,27 @@ class PositionReader(GGDVTKPluginBase):
                     if identifier != "":
                         name = f"{name} / {identifier}"
 
-                self.selectable_map[str(name)] = structure
+                pos = structure.position
+                if isinstance(pos, IDSStructArray):
+                    # Allow phi to be absent from the position vector, e.g. in the case
+                    # of 2D rotationally symmetric representations
+                    has_valid_position = any(
+                        cyl_vector_has_value(p, check_phi=False) for p in pos
+                    )
+                else:
+                    has_valid_position = cyl_vector_has_value(pos, check_phi=False)
+
+                if not has_valid_position:
+                    logger.warning("Skipping %s: no position set.", name)
+                    continue
+
+                name = ensure_unique_name(name, list(self.selectable_map.keys()))
+                self.selectable_map[name] = structure
         self._selectable = list(self.selectable_map)
+        if not self._selectable:
+            logger.error(
+                "No filled positions found in %s IDS.", self._ids.metadata.name
+            )
 
     def _load_position(self, output):
         """Go through the list of selected position structures, and load each of them
@@ -104,13 +124,12 @@ class PositionReader(GGDVTKPluginBase):
 
             if isinstance(pos, IDSStructArray):
                 for pos_struct in pos:
-                    pos_cart = (
-                        *pol_to_cart(pos_struct.r, pos_struct.phi),
-                        pos_struct.z,
-                    )
+                    phi = pos_struct.phi if pos_struct.phi.has_value else 0.0
+                    pos_cart = (*pol_to_cart(pos_struct.r, phi), pos_struct.z)
                     points.InsertNextPoint(*pos_cart)
             else:
-                pos_cart = (*pol_to_cart(pos.r, pos.phi), pos.z)
+                phi = pos.phi if pos.phi.has_value else 0.0
+                pos_cart = (*pol_to_cart(pos.r, phi), pos.z)
                 points.InsertNextPoint(*pos_cart)
 
         output.SetPoints(points)


### PR DESCRIPTION
Fixed the position reader to skip devices with unfilled positions. Also allow visualizing positions in cases where `phi` is left empty, for example in the case of 2D axisymmetric geometries, such as the WEST example in #80.