### PR TITLE
Standalone VTK support and coordinate conversion fix

### DIFF
--- a/docs/source/gallery/gallery.rst
+++ b/docs/source/gallery/gallery.rst
@@ -55,7 +55,11 @@ Example ``description.yaml``:
    description: |
      A description of what the visualization shows.
      Can be multiple lines.
-   uri: imas:hdf5?path=/path/on/sdcc # May also be a list of URIs
+   uri: imas:hdf5?path=/path/to/data/entry 
+   # Also multiple URIs may be provided, e.g.
+   # uri:
+   #   - imas:hdf5?path=/path/to/data/entry
+   #   - imas:hdf5?path=/path/to/another/entry
    link: www.example.com # Optional link (e.g. to dataset on Zenodo)
    imas_paraview_version: 2.3.0
 

--- a/imas_paraview/io/read_ps.py
+++ b/imas_paraview/io/read_ps.py
@@ -342,10 +342,15 @@ class PlasmaStateReader:
             angle = components.get(angle_key)
 
             if r is not None and angle is not None:
-                components["x"], components["y"] = pol_to_cart(r, angle)
-                # Remove r and phi components after conversion so magnitude stays useful
+                x, y = pol_to_cart(r, angle)
+                z = components.pop("z", None)
                 components.pop("r")
                 components.pop(angle_key)
+
+                components["x"] = x
+                components["y"] = y
+                if z is not None:
+                    components["z"] = z
 
         vtk_arr = vtkDoubleArray()
         vtk_arr.SetName(name)

--- a/imas_paraview/plugins/magnetics.py
+++ b/imas_paraview/plugins/magnetics.py
@@ -145,9 +145,9 @@ class MagneticsReader(GGDVTKPluginBase):
             self._add_b_field_probe(name, probe, "pol")
 
         # Toroidal field probes were renamed in DD 3.42.0
-        b_field_phi_probes = (
-            getattr(self._ids, "b_field_phi_probe", None) or self._ids.b_field_tor_probe
-        )
+        b_field_phi_probes = getattr(self._ids, "b_field_phi_probe", None)
+        if b_field_phi_probes is None:
+            b_field_phi_probes = self._ids.b_field_tor_probe
 
         for i, probe in enumerate(b_field_phi_probes):
             name = self._create_name("Toroidal field probe", probe, i)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,9 @@ dependencies = [
 all = [
     "imas_paraview[docs,test,linting,benchmark]"
 ]
+standalone= [
+    "vtk >= 9.1.0",
+]
 docs = [
     "sphinx>=6.0.0,<7.0.0",
     "sphinx-autosummary-accessors>=0.1.2",


### PR DESCRIPTION
Addresses comments from #82:
- Adds vtk optional dependency for running CLI tool standalone.
- Fixes ordering issue with coordinate conversion 
- Clarify docs