### PR TITLE
Cleanup main branch for v2.4.0

### DIFF
--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -3,6 +3,7 @@ name: build-wheel-and-publish-pypi
 on:
   push:
     branches: [main, develop]
+    tags: ["*"]
   pull_request:
     types: [opened, synchronize, reopened]
 

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -21,7 +21,7 @@
     // Customizable commands for building, installing, and
     // uninstalling the project. See asv.conf.json documentation.
     //
-    // "install_command": ["in-dir={env_dir} python -mpip install {wheel_file}[netcdf]"],
+    "install_command": ["in-dir={env_dir} python -mpip install {wheel_file}[standalone]"],
     // // "uninstall_command": ["return-code=any python -mpip uninstall -y {project}"],
     // "build_command": [
     //     // link data-dictionary and build folder so the DD source files remain cached


### PR DESCRIPTION
Introduces changes from #89, which fixes an issue with the release tag not triggering the PyPI publish job.